### PR TITLE
:sparkles: Feat: Material UI `ThemeProvider` 추가

### DIFF
--- a/src/app/(with-navbar)/layout.tsx
+++ b/src/app/(with-navbar)/layout.tsx
@@ -1,17 +1,6 @@
-import type { Metadata } from "next";
-import { Inter } from "next/font/google";
-import "../globals.css";
 import { Box } from "@mui/material";
 import { useViewport } from "@/hook/useViewport";
-import Sidebar from "@/components/layout/sidebar/sidebar";
 import NavigationBar from "@/components/layout/navbar";
-
-const inter = Inter({ subsets: ["latin"] });
-
-export const metadata: Metadata = {
-  title: "티끌 모아 펀딩",
-  description: "티끌 모아 펀딩",
-};
 
 export default function RootLayout({
   children,
@@ -21,13 +10,9 @@ export default function RootLayout({
   const { isMobile } = useViewport();
 
   return (
-    <html lang="ko">
-      <body className={inter.className}>
-        <Box>
-          {children}
-          {isMobile ? <NavigationBar /> : <NavigationBar />}
-        </Box>
-      </body>
-    </html>
+    <Box>
+      {children}
+      {isMobile ? <NavigationBar /> : <NavigationBar />}
+    </Box>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,26 @@
+import type { Metadata } from "next";
+import { Inter } from "next/font/google";
+import "./globals.css";
+import { ThemeProvider } from "@mui/material";
+import theme from "@/components/theme";
+
+const inter = Inter({ subsets: ["latin"] });
+
+export const metadata: Metadata = {
+  title: "Giftogether",
+  description: "Giftogether",
+};
+
+export default function RootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <html lang="ko">
+      <body className={inter.className}>
+        <ThemeProvider theme={theme}>{children}</ThemeProvider>
+      </body>
+    </html>
+  );
+}

--- a/src/components/VerticalImgCard.tsx
+++ b/src/components/VerticalImgCard.tsx
@@ -3,29 +3,14 @@
 import calculateDate from "@/utils/calculateDate";
 import React from "react";
 import {
-  styled,
+  Box,
   Card as MaterialCard,
+  CardActionArea,
   CardContent,
   CardMedia,
-  Typography,
-  CardActionArea,
   LinearProgress,
-  Box,
+  Typography,
 } from "@mui/material";
-import { linearProgressClasses } from "@mui/material/LinearProgress";
-
-const BorderLinearProgress = styled(LinearProgress)(({ theme }) => ({
-  height: 10,
-  borderRadius: 5,
-  [`&.${linearProgressClasses.colorPrimary}`]: {
-    backgroundColor:
-      theme.palette.grey[theme.palette.mode === "light" ? 200 : 800],
-  },
-  [`& .${linearProgressClasses.bar}`]: {
-    borderRadius: 5,
-    backgroundColor: theme.palette.mode === "light" ? "#FFC2C7" : "#E6E6E6",
-  },
-}));
 
 interface CardProps {
   image: string;
@@ -90,7 +75,7 @@ export default function VerticalImgCard({
               {closingDate()}
             </Typography>
           </Box>
-          <BorderLinearProgress variant="determinate" value={progress} />
+          <LinearProgress variant="determinate" value={progress} />
         </CardContent>
       </CardActionArea>
     </MaterialCard>

--- a/src/components/layout/action-bar/ActionBarButton.tsx
+++ b/src/components/layout/action-bar/ActionBarButton.tsx
@@ -6,8 +6,6 @@ export const ActionBarButton = styled(Button)(() => ({
   width: "100%",
   height: "100%",
   fontSize: 18,
-  fontWeight: 700,
   letterSpacing: 5,
   borderRadius: 10,
-  backgroundColor: red[300],
 }));

--- a/src/components/layout/navbar/bottom-navigation.tsx
+++ b/src/components/layout/navbar/bottom-navigation.tsx
@@ -14,6 +14,6 @@ export const StyledBottomNavigation = styled(BottomNavigation)(({ theme }) => ({
   },
   ".Mui-selected svg": {
     fontSize: 28,
-    color: red[300],
+    color: theme.palette.primary.main,
   },
 }));

--- a/src/components/theme/components.ts
+++ b/src/components/theme/components.ts
@@ -1,0 +1,9 @@
+import { Components } from "@mui/material/styles/components";
+import { Theme } from "@mui/material/styles/createTheme";
+import MuiLinearProgress from "@/components/theme/components/MuiLinearProgress";
+
+const components: Components<Omit<Theme, "components">> = {
+  MuiLinearProgress,
+};
+
+export default components;

--- a/src/components/theme/components/MuiLinearProgress.ts
+++ b/src/components/theme/components/MuiLinearProgress.ts
@@ -1,0 +1,21 @@
+import { linearProgressClasses } from "@mui/material/LinearProgress";
+import { grey } from "@mui/material/colors";
+import { Components } from "@mui/material/styles/components";
+
+const MuiLinearProgress: Components["MuiLinearProgress"] = {
+  styleOverrides: {
+    root: {
+      height: 10,
+      borderRadius: 5,
+      [`&.${linearProgressClasses.colorPrimary}`]: {
+        backgroundColor: grey[200],
+      },
+      [`& .${linearProgressClasses.bar}`]: {
+        borderRadius: 5,
+        backgroundColor: "#FFC2C7",
+      },
+    },
+  },
+};
+
+export default MuiLinearProgress;

--- a/src/components/theme/index.ts
+++ b/src/components/theme/index.ts
@@ -1,0 +1,11 @@
+"use client";
+import { createTheme } from "@mui/material/styles";
+import palette from "@/components/theme/palette";
+import components from "@/components/theme/components";
+
+const theme = createTheme({
+  palette,
+  components,
+});
+
+export default theme;

--- a/src/components/theme/palette.ts
+++ b/src/components/theme/palette.ts
@@ -1,0 +1,14 @@
+import { PaletteOptions } from "@mui/material";
+import { red } from "@mui/material/colors";
+
+const palette: PaletteOptions = {
+  primary: {
+    main: red[300],
+    contrastText: "#FFFFFF",
+  },
+  secondary: {
+    main: "#FFC2C7",
+  },
+};
+
+export default palette;


### PR DESCRIPTION
## 📝 PR 설명
* Material UI `ThemeProvider`를 추가했습니다.

## 🏷️ Jira

## 👀 비고
* Material UI `ThemeProvider`를 통해서 
   * primary 색상을 `red[300]`으로 지정했습니다.
   * `LinearProgress`의 기본 디자인을 `BorderLinearProgress`로 설정했습니다.