### PR TITLE
✨ Feat: 펀딩 상세 정보 조회 페이지 및 정보 탭 추가

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,14 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
     output: "standalone",
+    async rewrites() {
+        return [
+            {
+                source: "/api/:path*",
+                destination: "http://43.201.66.126:3000/api/:path*",
+            },
+        ];
+    },
 };
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.0",
     "@mui/icons-material": "^5.15.11",
+    "@mui/lab": "^5.0.0-alpha.170",
     "@mui/material": "^5.15.11",
     "@tanstack/react-query": "^5.29.2",
     "axios": "^1.6.8",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "@emotion/styled": "^11.11.0",
     "@mui/icons-material": "^5.15.11",
     "@mui/material": "^5.15.11",
+    "@tanstack/react-query": "^5.29.2",
+    "axios": "^1.6.8",
     "next": "14.1.0",
     "react": "^18",
     "react-dom": "^18"

--- a/src/app/(without-navbar)/fundings/[fundId]/page.tsx
+++ b/src/app/(without-navbar)/fundings/[fundId]/page.tsx
@@ -1,7 +1,30 @@
-export default function FundingDetailPage() {
+"use client";
+import { Stack } from "@mui/material";
+import useFundingDetailQuery from "@/query/useFundingsQuery";
+import FundingPageTab from "@/app/(without-navbar)/fundings/[fundId]/view/FundingPageTab";
+import FundingTitle from "@/app/(without-navbar)/fundings/[fundId]/view/FundingTitle";
+import FundingProgress from "@/app/(without-navbar)/fundings/[fundId]/view/FundingProgress";
+import FundingThumbnail from "@/app/(without-navbar)/fundings/[fundId]/view/FundingThumbnail";
+
+export default function FundingDetailPage({
+  params,
+}: {
+  params: { fundId: string };
+}) {
+  const { data: funding } = useFundingDetailQuery(params.fundId);
+
   return (
     <>
-      <h1>펀딩 상세 페이지</h1>
+      {funding && (
+        <Stack direction={"column"} spacing={1}>
+          <FundingThumbnail funding={funding} />
+          <Stack padding={3} spacing={2}>
+            <FundingTitle funding={funding} />
+            <FundingProgress funding={funding} />
+          </Stack>
+          <FundingPageTab funding={funding} />
+        </Stack>
+      )}
     </>
   );
 }

--- a/src/app/(without-navbar)/fundings/[fundId]/view/FundingInfoPanel.tsx
+++ b/src/app/(without-navbar)/fundings/[fundId]/view/FundingInfoPanel.tsx
@@ -1,0 +1,20 @@
+import { Typography } from "@mui/material";
+import { grey } from "@mui/material/colors";
+import { Funding } from "@/types/Funding";
+
+interface Props {
+  funding: Funding;
+}
+
+export default function FundingInfoPanel({ funding }: Props) {
+  const { fundCont } = funding;
+
+  return (
+    <>
+      <Typography variant="body1" color={grey[800]}>
+        {fundCont}
+      </Typography>
+      {/*TODO: 펀딩 상세 정보 조회 API에 선물 목록이 추가됐을 때 선물 목록 카드 추가하기*/}
+    </>
+  );
+}

--- a/src/app/(without-navbar)/fundings/[fundId]/view/FundingPageTab.tsx
+++ b/src/app/(without-navbar)/fundings/[fundId]/view/FundingPageTab.tsx
@@ -1,0 +1,37 @@
+import { SyntheticEvent, useState } from "react";
+import StickyTabs from "@/components/tab/StickyTabs";
+import FundingInfoPanel from "@/app/(without-navbar)/fundings/[fundId]/view/FundingInfoPanel";
+import type { Funding } from "@/types/Funding";
+
+interface Props {
+  funding: Funding;
+}
+
+export default function FundingPageTab({ funding }: Props) {
+  const [tab, setTab] = useState<string>("정보");
+
+  const handleTabChange = (event: SyntheticEvent, newTab: string) => {
+    setTab(newTab);
+  };
+
+  return (
+    <StickyTabs
+      tabs={[
+        {
+          label: "정보",
+          value: "정보",
+          panel: <FundingInfoPanel funding={funding} />,
+        },
+        {
+          label: "댓글",
+          value: "댓글",
+          panel: <></>,
+        },
+        { label: "감사인사", value: "감사인사", panel: <></> },
+        { label: "롤링페이퍼", value: "롤링페이퍼", panel: <></> },
+      ]}
+      selectedTab={tab}
+      handleTabChange={handleTabChange}
+    />
+  );
+}

--- a/src/app/(without-navbar)/fundings/[fundId]/view/FundingProgress.tsx
+++ b/src/app/(without-navbar)/fundings/[fundId]/view/FundingProgress.tsx
@@ -1,0 +1,18 @@
+import ProgressBarWithText from "@/components/progress/ProgressBarWithText";
+import calculatePercent from "@/utils/calculatePercent";
+import { Funding } from "@/types/Funding";
+
+interface Props {
+  funding: Funding;
+}
+
+export default function FundingProgress({ funding }: Props) {
+  const { fundSum, fundGoal, endAt } = funding;
+
+  return (
+    <ProgressBarWithText
+      progress={calculatePercent(fundSum, fundGoal)}
+      endDate={endAt}
+    />
+  );
+}

--- a/src/app/(without-navbar)/fundings/[fundId]/view/FundingThumbnail.tsx
+++ b/src/app/(without-navbar)/fundings/[fundId]/view/FundingThumbnail.tsx
@@ -1,0 +1,22 @@
+import FillImage from "@/components/image/FillImage";
+import { Funding } from "@/types/Funding";
+
+interface Props {
+  funding: Funding;
+}
+
+export default function FundingThumbnail({ funding }: Props) {
+  const { fundImg, fundTitle } = funding;
+
+  return (
+    <FillImage
+      src={fundImg ?? "/dummy/present.png"}
+      alt={`thumbnail-${fundTitle}`}
+      parentDivStyle={{
+        width: "100%",
+        aspectRatio: "1 / 1",
+        borderRadius: 10,
+      }}
+    />
+  );
+}

--- a/src/app/(without-navbar)/fundings/[fundId]/view/FundingTitle.tsx
+++ b/src/app/(without-navbar)/fundings/[fundId]/view/FundingTitle.tsx
@@ -1,0 +1,20 @@
+import { Chip, Stack, Typography } from "@mui/material";
+import { grey } from "@mui/material/colors";
+import { Funding } from "@/types/Funding";
+
+interface Props {
+  funding: Funding;
+}
+
+export default function FundingTitle({ funding }: Props) {
+  const { fundTitle, fundTheme } = funding;
+
+  return (
+    <Stack direction="row" spacing={1} alignItems="center">
+      <Typography variant={"h5"} fontWeight={700} color={grey[800]}>
+        {fundTitle}
+      </Typography>
+      <Chip label={fundTheme} size="small" sx={{ borderRadius: 2 }} />
+    </Stack>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Inter } from "next/font/google";
 import "./globals.css";
 import { ThemeProvider } from "@mui/material";
 import theme from "@/components/theme";
+import QueryClientProvider from "@/components/provider/QueryClientProvider";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -19,7 +20,9 @@ export default function RootLayout({
   return (
     <html lang="ko">
       <body className={inter.className}>
-        <ThemeProvider theme={theme}>{children}</ThemeProvider>
+        <ThemeProvider theme={theme}>
+          <QueryClientProvider>{children}</QueryClientProvider>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/src/components/image/FillImage.tsx
+++ b/src/components/image/FillImage.tsx
@@ -1,0 +1,23 @@
+import Image from "next/image";
+import type { CSSProperties } from "react";
+
+interface Props {
+  src: string;
+  alt: string;
+  parentDivStyle?: CSSProperties;
+}
+
+export default function FillImage({ src, alt, parentDivStyle }: Props) {
+  return (
+    <div
+      style={{
+        position: "relative",
+        overflow: "hidden",
+        objectFit: "cover",
+        ...parentDivStyle,
+      }}
+    >
+      <Image src={src} alt={alt} fill={true} />
+    </div>
+  );
+}

--- a/src/components/layout/action-bar/ActionBarStack.tsx
+++ b/src/components/layout/action-bar/ActionBarStack.tsx
@@ -10,4 +10,5 @@ export const ActionBarStack = styled(Stack)(() => ({
   height: 65,
   padding: 10,
   borderTop: "1px solid #eeeeee",
+  backgroundColor: "white",
 }));

--- a/src/components/progress/ProgressBarWithText.tsx
+++ b/src/components/progress/ProgressBarWithText.tsx
@@ -1,0 +1,48 @@
+import {
+  Box,
+  LinearProgress,
+  Stack,
+  Typography,
+  TypographyPropsVariantOverrides,
+} from "@mui/material";
+import { grey } from "@mui/material/colors";
+import getDeadlineStatus from "@/utils/getDeadlineStatus";
+import { OverridableStringUnion } from "@mui/types";
+import { Variant } from "@mui/material/styles/createTypography";
+
+interface Props {
+  progress: number;
+  endDate: string;
+  textSize?: OverridableStringUnion<
+    "inherit" | Variant,
+    TypographyPropsVariantOverrides
+  >;
+}
+
+export default function ProgressBarWithText({
+  progress,
+  endDate,
+  textSize,
+}: Props) {
+  return (
+    <Box>
+      <Stack direction={"row"} justifyContent={"space-between"} sx={{ mb: 1 }}>
+        <Typography
+          variant={textSize ?? "body1"}
+          fontWeight={700}
+          color="primary"
+        >
+          {`${progress}%`}
+        </Typography>
+        <Typography
+          variant={textSize ?? "body1"}
+          fontWeight={700}
+          color={grey[600]}
+        >
+          {getDeadlineStatus(endDate)}
+        </Typography>
+      </Stack>
+      <LinearProgress variant="determinate" value={Math.min(100, progress)} />
+    </Box>
+  );
+}

--- a/src/components/provider/QueryClientProvider.tsx
+++ b/src/components/provider/QueryClientProvider.tsx
@@ -1,0 +1,29 @@
+"use client";
+import {
+  QueryClient,
+  QueryClientProvider as ReactQueryClientProvider,
+} from "@tanstack/react-query";
+import { ReactNode, useState } from "react";
+
+interface Props {
+  children: ReactNode;
+}
+
+export default function QueryClientProvider({ children }: Props) {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            staleTime: 60 * 1000,
+          },
+        },
+      }),
+  );
+
+  return (
+    <ReactQueryClientProvider client={queryClient}>
+      {children}
+    </ReactQueryClientProvider>
+  );
+}

--- a/src/components/tab/StickyTabs.tsx
+++ b/src/components/tab/StickyTabs.tsx
@@ -1,0 +1,35 @@
+import type { SyntheticEvent } from "react";
+import { Box } from "@mui/material";
+import TabContext from "@mui/lab/TabContext";
+import type { TabInfo } from "@/components/tab/Tab.types";
+import TabItems from "@/components/tab/TabItems";
+import TabPanels from "@/components/tab/TabPanels";
+
+interface Props {
+  tabs: TabInfo[];
+  selectedTab: string | number;
+  handleTabChange: (event: SyntheticEvent, value: any) => void;
+}
+
+export default function StickyTabs({
+  tabs,
+  selectedTab,
+  handleTabChange,
+}: Props) {
+  return (
+    <TabContext value={selectedTab}>
+      <Box
+        sx={{
+          top: 0,
+          position: "sticky",
+          borderBottom: 1,
+          borderColor: "divider",
+          backgroundColor: "white",
+        }}
+      >
+        <TabItems tabs={tabs} handleTabChange={handleTabChange} />
+      </Box>
+      <TabPanels tabs={tabs} />
+    </TabContext>
+  );
+}

--- a/src/components/tab/Tab.types.ts
+++ b/src/components/tab/Tab.types.ts
@@ -1,0 +1,7 @@
+import type { ReactNode } from "react";
+
+export interface TabInfo {
+  label: ReactNode;
+  value: any;
+  panel: ReactNode;
+}

--- a/src/components/tab/TabItems.tsx
+++ b/src/components/tab/TabItems.tsx
@@ -1,0 +1,23 @@
+import type { SyntheticEvent } from "react";
+import Tab from "@mui/material/Tab";
+import TabList from "@mui/lab/TabList";
+import type { TabInfo } from "@/components/tab/Tab.types";
+
+interface Props {
+  tabs: TabInfo[];
+  handleTabChange: (event: SyntheticEvent, value: any) => void;
+}
+
+export default function TabItems({ tabs, handleTabChange }: Props) {
+  return (
+    <TabList onChange={handleTabChange} variant={"fullWidth"}>
+      {tabs.map((tab) => (
+        <Tab
+          key={`tab-${tab.label}-${tab.value}`}
+          label={tab.label}
+          value={tab.value}
+        />
+      ))}
+    </TabList>
+  );
+}

--- a/src/components/tab/TabPanels.tsx
+++ b/src/components/tab/TabPanels.tsx
@@ -1,0 +1,18 @@
+import TabPanel from "@mui/lab/TabPanel";
+import { TabInfo } from "@/components/tab/Tab.types";
+
+interface Props {
+  tabs: TabInfo[];
+}
+
+export default function TabPanels({ tabs }: Props) {
+  return (
+    <>
+      {tabs.map((tab) => (
+        <TabPanel key={`tab-panel-${tab.label}-${tab.value}`} value={tab.value}>
+          {tab.panel}
+        </TabPanel>
+      ))}
+    </>
+  );
+}

--- a/src/query/useFundingsQuery.ts
+++ b/src/query/useFundingsQuery.ts
@@ -1,0 +1,23 @@
+import axios from "axios";
+import { useQuery, UseQueryResult } from "@tanstack/react-query";
+import { Funding } from "@/types/Funding";
+import { CommonResponse } from "@/types/CommonResponse";
+
+const fetchFundingDetail = async (fundingUuid: string): Promise<Funding> => {
+  const response = await axios.get<CommonResponse<Funding>>(
+    `/api/funding/${fundingUuid}`,
+  );
+
+  return response.data.data;
+};
+
+const useFundingDetailQuery = (
+  fundingUuid: string,
+): UseQueryResult<Funding> => {
+  return useQuery<Funding>({
+    queryKey: ["funding", fundingUuid],
+    queryFn: () => fetchFundingDetail(fundingUuid),
+  });
+};
+
+export default useFundingDetailQuery;

--- a/src/types/CommonResponse.ts
+++ b/src/types/CommonResponse.ts
@@ -1,0 +1,5 @@
+export interface CommonResponse<T> {
+  timestamp: string;
+  message: string;
+  data: T;
+}

--- a/src/types/Funding.ts
+++ b/src/types/Funding.ts
@@ -1,0 +1,13 @@
+export interface Funding {
+  fundId: number;
+  fundUuid: string;
+  fundTitle: string;
+  fundCont: string;
+  fundImg: string;
+  fundTheme: string;
+  fundPubl: boolean;
+  fundGoal: number;
+  fundSum: number;
+  endAt: string;
+  regAt: string;
+}

--- a/src/utils/calculatePercent.ts
+++ b/src/utils/calculatePercent.ts
@@ -1,0 +1,7 @@
+export default function calculatePercent(
+  numerator: number,
+  denominator: number,
+) {
+  const percentage = (numerator / denominator) * 100;
+  return Math.floor(percentage);
+}

--- a/src/utils/getDeadlineStatus.ts
+++ b/src/utils/getDeadlineStatus.ts
@@ -1,0 +1,9 @@
+import calculateDate from "@/utils/calculateDate";
+
+export default function getDeadlineStatus(deadlineDate: string) {
+  const remainingDays = calculateDate(new Date(), deadlineDate);
+
+  if (remainingDays > 0) return `${remainingDays}일 남음`;
+  else if (remainingDays === 0) return "오늘 마감";
+  else return "만료됨";
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -445,6 +445,18 @@
   dependencies:
     tslib "^2.4.0"
 
+"@tanstack/query-core@5.29.0":
+  version "5.29.0"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.29.0.tgz#d0b3d12c07d5a47f42ab0c1ed4f317106f3d4b20"
+  integrity sha512-WgPTRs58hm9CMzEr5jpISe8HXa3qKQ8CxewdYZeVnA54JrPY9B1CZiwsCoLpLkf0dGRZq+LcX5OiJb0bEsOFww==
+
+"@tanstack/react-query@^5.29.2":
+  version "5.29.2"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-5.29.2.tgz#c55ffbfaf9d8cf34212428db2b6c61ca6b545188"
+  integrity sha512-nyuWILR4u7H5moLGSiifLh8kIqQDLNOHGuSz0rcp+J75fNc8aQLyr5+I2JCHU3n+nJrTTW1ssgAD8HiKD7IFBQ==
+  dependencies:
+    "@tanstack/query-core" "5.29.0"
+
 "@types/json5@^0.0.29":
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
@@ -731,6 +743,11 @@ asynciterator.prototype@^1.0.0:
   dependencies:
     has-symbols "^1.0.3"
 
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
 available-typed-arrays@^1.0.6, available-typed-arrays@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz#a5cc375d6a03c2efc87a553f3e0b1522def14846"
@@ -742,6 +759,15 @@ axe-core@=4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.7.0.tgz#34ba5a48a8b564f67e103f0aa5768d76e15bbbbf"
   integrity sha512-M0JtH+hlOL5pLQwHOLNYZaXuhqmvS8oExsqB1SBYgA4Dk7u/xx+YdGHXaK5pyUfed5mYXdlYiphWq3G8cRi5JQ==
+
+axios@^1.6.8:
+  version "1.6.8"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.8.tgz#66d294951f5d988a00e87a0ffb955316a619ea66"
+  integrity sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==
+  dependencies:
+    follow-redirects "^1.15.6"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
 
 axobject-query@^3.2.1:
   version "3.2.1"
@@ -865,6 +891,13 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -941,6 +974,11 @@ define-properties@^1.1.3, define-properties@^1.2.0, define-properties@^1.2.1:
     define-data-property "^1.0.1"
     has-property-descriptors "^1.0.0"
     object-keys "^1.1.1"
+
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
 dequal@^2.0.3:
   version "2.0.3"
@@ -1408,6 +1446,11 @@ flatted@^3.2.9:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.3.1.tgz#21db470729a6734d4997002f439cb308987f567a"
   integrity sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==
 
+follow-redirects@^1.15.6:
+  version "1.15.6"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#7f815c0cda4249c74ff09e95ef97c23b5fd0399b"
+  integrity sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==
+
 for-each@^0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
@@ -1422,6 +1465,15 @@ foreground-child@^3.1.0:
   dependencies:
     cross-spawn "^7.0.0"
     signal-exit "^4.0.1"
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -1976,6 +2028,18 @@ micromatch@^4.0.4:
     braces "^3.0.2"
     picomatch "^2.3.1"
 
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
+mime-types@^2.1.12:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
+
 minimatch@9.0.3, minimatch@^9.0.1:
   version "9.0.3"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.3.tgz#a6e00c3de44c3a542bfaae70abfc22420a6da825"
@@ -2239,6 +2303,11 @@ prop-types@^15.6.2, prop-types@^15.8.1:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.13.1"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 punycode@^2.1.0:
   version "2.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -267,6 +267,19 @@
     clsx "^2.1.0"
     prop-types "^15.8.1"
 
+"@mui/base@5.0.0-beta.40":
+  version "5.0.0-beta.40"
+  resolved "https://registry.yarnpkg.com/@mui/base/-/base-5.0.0-beta.40.tgz#1f8a782f1fbf3f84a961e954c8176b187de3dae2"
+  integrity sha512-I/lGHztkCzvwlXpjD2+SNmvNQvB4227xBXhISPjEaJUXGImOQ9f3D2Yj/T3KasSI/h0MLWy74X0J6clhPmsRbQ==
+  dependencies:
+    "@babel/runtime" "^7.23.9"
+    "@floating-ui/react-dom" "^2.0.8"
+    "@mui/types" "^7.2.14"
+    "@mui/utils" "^5.15.14"
+    "@popperjs/core" "^2.11.8"
+    clsx "^2.1.0"
+    prop-types "^15.8.1"
+
 "@mui/core-downloads-tracker@^5.15.11":
   version "5.15.11"
   resolved "https://registry.yarnpkg.com/@mui/core-downloads-tracker/-/core-downloads-tracker-5.15.11.tgz#dcaf6156880e81e4547237fb781700485453e964"
@@ -278,6 +291,19 @@
   integrity sha512-R5ZoQqnKpd+5Ew7mBygTFLxgYsQHPhgR3TDXSgIHYIjGzYuyPLmGLSdcPUoMdi6kxiYqHlpPj4NJxlbaFD0UHA==
   dependencies:
     "@babel/runtime" "^7.23.9"
+
+"@mui/lab@^5.0.0-alpha.170":
+  version "5.0.0-alpha.170"
+  resolved "https://registry.yarnpkg.com/@mui/lab/-/lab-5.0.0-alpha.170.tgz#4519dfc8d1c51ca54fb9d8b91b95a3733d07be16"
+  integrity sha512-0bDVECGmrNjd3+bLdcLiwYZ0O4HP5j5WSQm5DV6iA/Z9kr8O6AnvZ1bv9ImQbbX7Gj3pX4o43EKwCutj3EQxQg==
+  dependencies:
+    "@babel/runtime" "^7.23.9"
+    "@mui/base" "5.0.0-beta.40"
+    "@mui/system" "^5.15.15"
+    "@mui/types" "^7.2.14"
+    "@mui/utils" "^5.15.14"
+    clsx "^2.1.0"
+    prop-types "^15.8.1"
 
 "@mui/material@^5.15.11":
   version "5.15.11"
@@ -306,10 +332,29 @@
     "@mui/utils" "^5.15.11"
     prop-types "^15.8.1"
 
+"@mui/private-theming@^5.15.14":
+  version "5.15.14"
+  resolved "https://registry.yarnpkg.com/@mui/private-theming/-/private-theming-5.15.14.tgz#edd9a82948ed01586a01c842eb89f0e3f68970ee"
+  integrity sha512-UH0EiZckOWcxiXLX3Jbb0K7rC8mxTr9L9l6QhOZxYc4r8FHUkefltV9VDGLrzCaWh30SQiJvAEd7djX3XXY6Xw==
+  dependencies:
+    "@babel/runtime" "^7.23.9"
+    "@mui/utils" "^5.15.14"
+    prop-types "^15.8.1"
+
 "@mui/styled-engine@^5.15.11":
   version "5.15.11"
   resolved "https://registry.yarnpkg.com/@mui/styled-engine/-/styled-engine-5.15.11.tgz#040181f31910e0f66d43a5c44fe89da06b34212b"
   integrity sha512-So21AhAngqo07ces4S/JpX5UaMU2RHXpEA6hNzI6IQjd/1usMPxpgK8wkGgTe3JKmC2KDmH8cvoycq5H3Ii7/w==
+  dependencies:
+    "@babel/runtime" "^7.23.9"
+    "@emotion/cache" "^11.11.0"
+    csstype "^3.1.3"
+    prop-types "^15.8.1"
+
+"@mui/styled-engine@^5.15.14":
+  version "5.15.14"
+  resolved "https://registry.yarnpkg.com/@mui/styled-engine/-/styled-engine-5.15.14.tgz#168b154c4327fa4ccc1933a498331d53f61c0de2"
+  integrity sha512-RILkuVD8gY6PvjZjqnWhz8fu68dVkqhM5+jYWfB5yhlSQKg+2rHkmEwm75XIeAqI3qwOndK6zELK5H6Zxn4NHw==
   dependencies:
     "@babel/runtime" "^7.23.9"
     "@emotion/cache" "^11.11.0"
@@ -330,15 +375,44 @@
     csstype "^3.1.3"
     prop-types "^15.8.1"
 
+"@mui/system@^5.15.15":
+  version "5.15.15"
+  resolved "https://registry.yarnpkg.com/@mui/system/-/system-5.15.15.tgz#658771b200ce3c4a0f28e58169f02e5e718d1c53"
+  integrity sha512-aulox6N1dnu5PABsfxVGOZffDVmlxPOVgj56HrUnJE8MCSh8lOvvkd47cebIVQQYAjpwieXQXiDPj5pwM40jTQ==
+  dependencies:
+    "@babel/runtime" "^7.23.9"
+    "@mui/private-theming" "^5.15.14"
+    "@mui/styled-engine" "^5.15.14"
+    "@mui/types" "^7.2.14"
+    "@mui/utils" "^5.15.14"
+    clsx "^2.1.0"
+    csstype "^3.1.3"
+    prop-types "^15.8.1"
+
 "@mui/types@^7.2.13":
   version "7.2.13"
   resolved "https://registry.yarnpkg.com/@mui/types/-/types-7.2.13.tgz#d1584912942f9dc042441ecc2d1452be39c666b8"
   integrity sha512-qP9OgacN62s+l8rdDhSFRe05HWtLLJ5TGclC9I1+tQngbssu0m2dmFZs+Px53AcOs9fD7TbYd4gc9AXzVqO/+g==
 
+"@mui/types@^7.2.14":
+  version "7.2.14"
+  resolved "https://registry.yarnpkg.com/@mui/types/-/types-7.2.14.tgz#8a02ac129b70f3d82f2f9b76ded2c8d48e3fc8c9"
+  integrity sha512-MZsBZ4q4HfzBsywtXgM1Ksj6HDThtiwmOKUXH1pKYISI9gAVXCNHNpo7TlGoGrBaYWZTdNoirIN7JsQcQUjmQQ==
+
 "@mui/utils@^5.15.11":
   version "5.15.11"
   resolved "https://registry.yarnpkg.com/@mui/utils/-/utils-5.15.11.tgz#a71804d6d6025783478fd1aca9afbf83d9b789c7"
   integrity sha512-D6bwqprUa9Stf8ft0dcMqWyWDKEo7D+6pB1k8WajbqlYIRA8J8Kw9Ra7PSZKKePGBGWO+/xxrX1U8HpG/aXQCw==
+  dependencies:
+    "@babel/runtime" "^7.23.9"
+    "@types/prop-types" "^15.7.11"
+    prop-types "^15.8.1"
+    react-is "^18.2.0"
+
+"@mui/utils@^5.15.14":
+  version "5.15.14"
+  resolved "https://registry.yarnpkg.com/@mui/utils/-/utils-5.15.14.tgz#e414d7efd5db00bfdc875273a40c0a89112ade3a"
+  integrity sha512-0lF/7Hh/ezDv5X7Pry6enMsbYyGKjADzvHyo3Qrc/SSlTsQ1VkbDMbH0m2t3OR5iIVLwMoxwM7yGd+6FCMtTFA==
   dependencies:
     "@babel/runtime" "^7.23.9"
     "@types/prop-types" "^15.7.11"


### PR DESCRIPTION
## 📝 PR 설명
### 1) 펀딩 상세 정보 조회 페이지의 정보 탭 추가
![Apr-17-2024 15-16-45](https://github.com/coding-jjun/wishlist_funding_frontend/assets/68776394/1fb6ef51-f545-45fc-9548-821638a91e01)

### 2) React Query 설정 추가
* React Query의 maintainer인 [TkDodo의 블로그 글](https://tkdodo.eu/blog/practical-react-query)을 참고하여 `useFundingDetailQuery`과 같은 형태로 React Query를 사용하도록 작성했습니다.

### 3) `CommonResponse<T>` 타입 추가
* API 응답에 대한 타입으로 사용할 수 있도록 `CommonResponse<T>` 타입을 추가했습니다. `CommonResponse<data 필드의 타입>`과 같은 형태로 사용하시면 됩니다.
* `nextConfig`에 `rewrites` 설정을 추가해서 API 요청을 보낼 때 URL은 `http://43.201.66.126:3000/api/~~`가 아닌 `/api/~~`의 형태로 사용하면 됩니다.

### 4) 유틸 함수 추가
* `VerticalImgCard`에 있던 `closingDate()` 함수를 `getDeadlineStatus()` 함수로 분리했습니다.
* 퍼센트 계산에 사용할 수 있도록 `calculatePercent()` 함수를 추가했습니다.

### 5) `FillImage` 컴포넌트 추가
* 이미지가 부모 요소를 채우도록 할 때 사용할 수 있도록 `FillImage` 컴포넌트를 추가했습니다.
* 부모 div 요소에 대해 추가적으로 부여하고 싶은 스타일은 `parentDivStyle`에 전달하면 됩니다.

## 🏷️ Jira
[WISH-68](https://wishfund.atlassian.net/browse/WISH-68?atlOrigin=eyJpIjoiNDNlODVjZDA3MjFkNGZmNDg0MTRjYTE4YmNmMjFmYTYiLCJwIjoiaiJ9)

## 👀 비고


[WISH-68]: https://wishfund.atlassian.net/browse/WISH-68?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ