### PR TITLE
✨ Feat: 펀딩 상세 정보 조회 페이지 - 롤링페이퍼 탭 추가

### DIFF
--- a/src/app/(without-navbar)/fundings/[fundId]/view/FundingPageTab.tsx
+++ b/src/app/(without-navbar)/fundings/[fundId]/view/FundingPageTab.tsx
@@ -4,6 +4,7 @@ import FundingInfoPanel from "@/app/(without-navbar)/fundings/[fundId]/view/Fund
 import type { Funding } from "@/types/Funding";
 import CommentPanel from "@/app/(without-navbar)/fundings/[fundId]/view/CommentPanel";
 import GratitudePanel from "@/app/(without-navbar)/fundings/[fundId]/view/GratitudePanel";
+import RollingPaperPanel from "@/app/(without-navbar)/fundings/[fundId]/view/RollingPaperPanel";
 
 interface Props {
   funding: Funding;
@@ -35,7 +36,11 @@ export default function FundingPageTab({ funding }: Props) {
           // TODO: Funding 객체 내에 gratId가 추가되면 funding.gratId를 전달하도록 수정 필요
           panel: <GratitudePanel gratId={1} />,
         },
-        { label: "롤링페이퍼", value: "롤링페이퍼", panel: <></> },
+        {
+          label: "롤링페이퍼",
+          value: "롤링페이퍼",
+          panel: <RollingPaperPanel fundUuid={funding.fundUuid} />,
+        },
       ]}
       selectedTab={tab}
       handleTabChange={handleTabChange}

--- a/src/app/(without-navbar)/fundings/[fundId]/view/GratitudePanel.tsx
+++ b/src/app/(without-navbar)/fundings/[fundId]/view/GratitudePanel.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Button, Stack, Typography } from "@mui/material";
 import CoverImage from "@/components/image/CoverImage";
 import useGratitudeQuery from "@/query/useGratitudeQuery";
-import ProfileWithDate from "@/components/profile/ProfileWithDate";
+import Profile from "@/components/profile/Profile";
 import { SwiperWithThumbs } from "@/components/swiper";
 import { grey } from "@mui/material/colors";
 
@@ -26,10 +26,7 @@ export default function GratitudePanel({ gratId }: Props) {
       {gratitude ? (
         <Stack direction="column" spacing={2}>
           {/*TODO: Funding 객체 또는 Gratitude 객체에 유저 정보가 추가되면 userName 하드코딩 제거 필요*/}
-          <ProfileWithDate
-            userName="홍길동"
-            regAt={gratitude?.regAt.toString()}
-          />
+          <Profile userName="홍길동" regAt={gratitude?.regAt.toString()} />
           <Typography variant="body1">{gratitude?.gratCont}</Typography>
           <SwiperWithThumbs
             slides={DUMMY_IMAGES.map((image) => ({

--- a/src/app/(without-navbar)/fundings/[fundId]/view/RollingPaperPanel.tsx
+++ b/src/app/(without-navbar)/fundings/[fundId]/view/RollingPaperPanel.tsx
@@ -1,0 +1,38 @@
+import useRollingPapersQuery from "@/query/useRollingPapersQuery";
+import { Stack, Typography } from "@mui/material";
+import { ProfileBox } from "@/components/profile";
+import { MoneyChip } from "@/components/chip";
+import { SizeToggleImage } from "@/components/image";
+
+interface Props {
+  fundUuid: string;
+}
+
+export default function RollingPaperPanel({ fundUuid }: Props) {
+  const { data: rollingPapers } = useRollingPapersQuery(fundUuid);
+
+  return (
+    <>
+      {rollingPapers?.map((paper) => (
+        <ProfileBox
+          key={`rolling-paper-${paper.rollId}`}
+          userName={paper?.donation?.user?.userNick ?? "익명"}
+          regAt={paper.donation?.regAt.toString()}
+          description={<MoneyChip amount={paper.donation.donAmnt} />}
+          content={
+            <Stack direction="column" spacing={1}>
+              <Typography variant="body1">{paper.rollMsg}</Typography>
+              {paper.rollImg ?? (
+                <SizeToggleImage
+                  src={paper.rollImg}
+                  alt={"롤링페이퍼"}
+                  width={100}
+                />
+              )}
+            </Stack>
+          }
+        />
+      ))}
+    </>
+  );
+}

--- a/src/components/chip/MoneyChip.tsx
+++ b/src/components/chip/MoneyChip.tsx
@@ -1,0 +1,24 @@
+import { Avatar, Chip, Typography } from "@mui/material";
+import { grey } from "@mui/material/colors";
+import addComma from "@/utils/addComma";
+
+interface Props {
+  amount: number;
+  size?: "small" | "medium";
+}
+
+export default function MoneyChip({ amount, size = "small" }: Props) {
+  return (
+    <Chip
+      icon={
+        <Avatar sx={{ width: 20, height: 20 }}>
+          <Typography variant="body2" sx={{ color: grey[700] }}>
+            ₩
+          </Typography>
+        </Avatar>
+      }
+      label={addComma(amount)}
+      size={size}
+    />
+  );
+}

--- a/src/components/chip/index.ts
+++ b/src/components/chip/index.ts
@@ -1,0 +1,1 @@
+export { default as MoneyChip } from "./MoneyChip";

--- a/src/components/icon/FullSizeIcon.tsx
+++ b/src/components/icon/FullSizeIcon.tsx
@@ -1,0 +1,38 @@
+import { CSSProperties } from "react";
+import { Box } from "@mui/material";
+import { grey } from "@mui/material/colors";
+import FullscreenExitIcon from "@mui/icons-material/FullscreenExit";
+import FullscreenIcon from "@mui/icons-material/Fullscreen";
+
+interface Props {
+  fullSize: boolean;
+  boxSx?: CSSProperties;
+}
+
+export default function FullSizeIcon({ fullSize, boxSx }: Props) {
+  return (
+    <Box
+      sx={{
+        bgcolor: grey[500],
+        position: "absolute",
+        top: 5,
+        left: 5,
+        opacity: 0.5,
+        width: 20,
+        height: 20,
+        borderRadius: 1,
+        color: "white",
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
+        ...boxSx,
+      }}
+    >
+      {fullSize ? (
+        <FullscreenExitIcon fontSize="small" />
+      ) : (
+        <FullscreenIcon fontSize="small" />
+      )}
+    </Box>
+  );
+}

--- a/src/components/icon/index.ts
+++ b/src/components/icon/index.ts
@@ -1,0 +1,1 @@
+export { default as FullSizeIcon } from "./FullSizeIcon";

--- a/src/components/image/ContainImage.tsx
+++ b/src/components/image/ContainImage.tsx
@@ -1,0 +1,28 @@
+import Image from "next/image";
+import { CSSProperties } from "react";
+
+interface Props {
+  src: string;
+  alt: string;
+  parentDivStyle?: CSSProperties;
+}
+
+export default function ContainImage({ src, alt, parentDivStyle }: Props) {
+  return (
+    <div
+      style={{
+        width: "auto",
+        height: "30vh",
+        ...parentDivStyle,
+      }}
+    >
+      <Image
+        src={src}
+        alt={alt}
+        fill={true}
+        objectFit="contain"
+        objectPosition="left top"
+      />
+    </div>
+  );
+}

--- a/src/components/image/SizeToggleImage.tsx
+++ b/src/components/image/SizeToggleImage.tsx
@@ -1,0 +1,39 @@
+import { CSSProperties, useState } from "react";
+import CoverImage from "@/components/image/CoverImage";
+import ContainImage from "@/components/image/ContainImage";
+import { FullSizeIcon } from "@/components/icon";
+
+interface Props {
+  src: string;
+  alt: string;
+  width: number;
+  parentDivStyle?: CSSProperties;
+}
+
+export default function SizeToggleImage({
+  src,
+  alt,
+  width,
+  parentDivStyle,
+}: Props) {
+  const [fullSize, setFullSize] = useState<boolean>(false);
+
+  const toggleSize = () => {
+    setFullSize((prev) => !prev);
+  };
+
+  return (
+    <div onClick={toggleSize} style={{ position: "relative" }}>
+      {fullSize ? (
+        <ContainImage src={src} alt={alt} />
+      ) : (
+        <CoverImage
+          src={src}
+          alt={alt}
+          parentDivStyle={{ ...parentDivStyle, width: width }}
+        />
+      )}
+      <FullSizeIcon fullSize={fullSize} />
+    </div>
+  );
+}

--- a/src/components/image/index.ts
+++ b/src/components/image/index.ts
@@ -1,0 +1,3 @@
+export { default as SizeToggleImage } from "./SizeToggleImage";
+export { default as ContainImage } from "./ContainImage";
+export { default as CoverImage } from "./CoverImage";

--- a/src/components/profile/Profile.tsx
+++ b/src/components/profile/Profile.tsx
@@ -4,14 +4,16 @@ import getTimeAgoText from "@/utils/getTimeAgoText";
 
 interface Props {
   userName: string;
-  regAt?: string;
   profileImg?: string;
+  regAt?: string;
+  description?: React.ReactNode;
 }
 
-export default function ProfileWithDate({
+export default function Profile({
   profileImg,
   userName,
   regAt,
+  description,
 }: Props) {
   return (
     <Stack
@@ -21,6 +23,7 @@ export default function ProfileWithDate({
       spacing={2}
       sx={{ width: "100%", position: "relative" }}
     >
+      {/*프로필 이미지*/}
       <Avatar
         alt={`${userName}-profile-avatar`}
         src={profileImg ?? "/dummy/profile.png"}
@@ -32,14 +35,18 @@ export default function ProfileWithDate({
         alignItems="center"
         spacing={1}
       >
+        {/*닉네임*/}
         <Typography fontWeight={700} margin="none">
           {userName}
         </Typography>
+        {/*등록일*/}
         {regAt && (
           <Typography variant="body2" color={grey[500]} margin="none">
             {getTimeAgoText(regAt)}
           </Typography>
         )}
+        {/*부가정보*/}
+        {description}
       </Stack>
     </Stack>
   );

--- a/src/components/profile/ProfileBox.tsx
+++ b/src/components/profile/ProfileBox.tsx
@@ -1,0 +1,25 @@
+import { Stack } from "@mui/material";
+import Profile from "@/components/profile/Profile";
+
+interface Props {
+  userName: string;
+  content: React.ReactNode;
+  profileImg?: string;
+  regAt?: string;
+  description?: React.ReactNode;
+}
+
+export default function ProfileBox({ content, ...props }: Props) {
+  return (
+    <Stack
+      direction="column"
+      justifyContent="flex-start"
+      alignItems="flex-start"
+      spacing={1}
+      sx={{ pb: 3, width: "100%" }}
+    >
+      <Profile {...props} />
+      <div style={{ marginLeft: 50 }}>{content}</div>
+    </Stack>
+  );
+}

--- a/src/components/profile/index.ts
+++ b/src/components/profile/index.ts
@@ -1,0 +1,2 @@
+export { default as Profile } from "./Profile";
+export { default as ProfileBox } from "./ProfileBox";

--- a/src/query/useRollingPapersQuery.ts
+++ b/src/query/useRollingPapersQuery.ts
@@ -1,0 +1,25 @@
+import axios from "axios";
+import { useQuery, UseQueryResult } from "@tanstack/react-query";
+import { CommonResponse } from "@/types/CommonResponse";
+import { RollingPaper } from "@/types/RollingPaper";
+
+const fetchRollingPapers = async (
+  fundUuid: string,
+): Promise<RollingPaper[]> => {
+  const response = await axios.get<CommonResponse<RollingPaper[]>>(
+    `/api/rollingpaper?fundUuid=${fundUuid}`,
+  );
+
+  return response.data.data;
+};
+
+const useRollingPapersQuery = (
+  fundUuid: string,
+): UseQueryResult<RollingPaper[]> => {
+  return useQuery<RollingPaper[]>({
+    queryKey: ["rollingPapers", fundUuid],
+    queryFn: () => fetchRollingPapers(fundUuid),
+  });
+};
+
+export default useRollingPapersQuery;

--- a/src/types/Donation.ts
+++ b/src/types/Donation.ts
@@ -1,0 +1,14 @@
+import { Funding } from "@/types/Funding";
+import { User } from "@/types/User";
+import { DonationStatus } from "@/types/DonationStatus";
+
+export interface Donation {
+  donId: number;
+  funding: Funding;
+  user: User;
+  donationStatus: DonationStatus;
+  orderId: string;
+  donAmnt: number;
+  regAt: Date;
+  delAt: Date;
+}

--- a/src/types/DonationStatus.ts
+++ b/src/types/DonationStatus.ts
@@ -1,0 +1,5 @@
+export enum DonationStatus {
+  Donated = "후원",
+  WaitingRefund = "환불 대기중",
+  RefundComplete = "환불 완료",
+}

--- a/src/types/RollingPaper.ts
+++ b/src/types/RollingPaper.ts
@@ -1,0 +1,10 @@
+import { Donation } from "@/types/Donation";
+
+export interface RollingPaper {
+  rollId: number;
+  donation: Donation;
+  fundId: number;
+  rollImg: string;
+  rollMsg: string;
+  delAt?: Date;
+}

--- a/src/types/User.ts
+++ b/src/types/User.ts
@@ -1,0 +1,20 @@
+import { Funding } from "@/types/Funding";
+import { Comment } from "@/types/Comment";
+
+// TODO: account, image, addressed 타입 수정 필요
+export interface User {
+  userId: number;
+  userNick: string;
+  userPw: string;
+  userName: string;
+  userPhone: string;
+  userEmail: string;
+  userBirth: Date;
+  account: any;
+  image: any;
+  regAt: Date;
+  delAt: Date;
+  fundings: Funding[];
+  comments: Comment[];
+  addresses: any[];
+}


### PR DESCRIPTION
## 📝 PR 설명
### 펀딩 상세 페이지 - 롤링페이퍼 탭 추가
![May-03-2024 16-04-55](https://github.com/coding-jjun/wishlist_funding_frontend/assets/68776394/5137c448-bef2-484b-86c4-ce63ef894247)

## 🏷️ Jira
[WISH-96](https://wishfund.atlassian.net/browse/WISH-96?atlOrigin=eyJpIjoiOTk5NmU4YzEyYTM0NDNiMGE3ZjFjYzI5MjlmMTRlNWUiLCJwIjoiaiJ9)

## 👀 비고
_리뷰어가 참고해야 할 사항이 있으면 적어주세요._

* 이미지의 `object-fit`을 `contain`으로 사용할 수 있도록 `ContainImage` 컴포넌트를 추가했습니다.
* 이미지를 확대 / 축소해서 볼 수 있도록 `SizeToggleImage` 컴포넌트를 추가했습니다.
* 아래와 같이 프로필 이미지, 닉네임, 등록일, 본문 영역이 있는 형태로 구현할 때 사용할 수 있도록 `ProfileBox` 컴포넌트를 추가했습니다.
<img width="297" alt="image" src="https://github.com/coding-jjun/wishlist_funding_frontend/assets/68776394/e27c81eb-4ec8-4471-b81d-70ebbc0dbeeb">


[WISH-96]: https://wishfund.atlassian.net/browse/WISH-96?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ