### PR TITLE
:bug: Fix: 다른 페이지에 갔다왔을 때 Swiper 컴포넌트 비율이 깨지는 버그 해결

### DIFF
--- a/src/app/(with-navbar)/page.tsx
+++ b/src/app/(with-navbar)/page.tsx
@@ -51,7 +51,11 @@ export default function Home() {
             }
           />
         )}
-        <MyFundingSwiper pagination={true} modules={[Pagination]}>
+        <MyFundingSwiper
+          pagination={true}
+          modules={[Pagination]}
+          style={{ width: "100%", height: "100%" }}
+        >
           {myFundingQueryResponse?.pages
             ?.flatMap((page) => page.fundings)
             .map((funding) => (

--- a/src/components/card/HorizontalImgCard.tsx
+++ b/src/components/card/HorizontalImgCard.tsx
@@ -34,7 +34,7 @@ export default function HorizontalImgCard({
       <CardActionArea sx={{ display: "flex" }} onClick={handleClick}>
         <CardMedia
           component="img"
-          sx={{ width: 140 }}
+          sx={{ width: 140, height: 140, flexShrink: 0, maxWidth: 140 }}
           image={image}
           alt="펀딩 썸네일"
         />


### PR DESCRIPTION
## 📝 PR 설명
* 다른 페이지로부터 메인 페이지로 넘어오면 메인 페이지의 나의 펀딩 섹션에 Swiper 컴포넌트의 비율이 깨지는 버그를 해결했습니다.

### 🔻 문제상황
<img width="327" alt="image" src="https://github.com/coding-jjun/wishlist_funding_frontend/assets/68776394/bfe0993d-84ca-47ae-93c3-f076b561876c">


## 🏷️ Jira

## 👀 비고
_리뷰어가 참고해야 할 사항이 있으면 적어주세요._
