### PR TITLE
:bug: Fix: 펀딩 목록 조회 페이지에서 필터 모양이 깨지는 문제 해결

### DIFF
--- a/src/app/(with-navbar)/fundings/view/FilterSelectBar.tsx
+++ b/src/app/(with-navbar)/fundings/view/FilterSelectBar.tsx
@@ -42,32 +42,41 @@ export default function FilterSelectBar() {
     <Stack
       direction="row"
       spacing={1}
-      justifyContent={"flex-end"}
-      sx={{ display: "flex" }}
+      justifyContent={"flex-start"}
+      sx={{
+        flexGrow: 1,
+        overflowX: "auto",
+        whiteSpace: "nowrap",
+        "&::-webkit-scrollbar": {
+          display: "none",
+        },
+        msOverflowStyle: "none",
+        scrollbarWidth: "none",
+      }}
     >
       <FilterSelect
         label="테마"
         handleClick={openBottomSheet}
         selected={themes.length !== 3}
-        sx={{ flexGrow: 1 }}
+        sx={{ flexShrink: 0 }}
       />
       <FilterSelect
         label={visibility === "전체" ? "공개범위" : visibility}
         handleClick={openBottomSheet}
         selected={visibility !== "전체"}
-        sx={{ flexGrow: 1 }}
+        sx={{ flexShrink: 0 }}
       />
       <FilterSelect
         label={status === "진행 중" ? "진행상태" : status}
         handleClick={openBottomSheet}
         selected={status !== "진행 중"}
-        sx={{ flexGrow: 1 }}
+        sx={{ flexShrink: 0 }}
       />
       <FilterSelect
         label={sort}
         handleClick={openBottomSheet}
         selected={sort !== "마감일순"}
-        sx={{ flexGrow: 1 }}
+        sx={{ flexShrink: 0 }}
       />
     </Stack>
   );

--- a/src/components/filter/FilterSelect.tsx
+++ b/src/components/filter/FilterSelect.tsx
@@ -23,6 +23,8 @@ export function FilterSelect({ label, handleClick, selected, sx }: Props) {
         px: 1,
         color: selected ? "#FFFFFF" : undefined,
         backgroundColor: selected ? grey[800] : "#FFFFFF",
+        flexShrink: 0,
+        whiteSpace: "nowrap",
         ...sx,
       }}
     >


### PR DESCRIPTION
## 📝 PR 설명
* 펀딩 목록 조회 페이지에서 모바일 기기에 따라 필터 모양이 깨지는 문제를 해결했습니다.

### 🔻 문제상황
<img width="327" alt="image" src="https://github.com/coding-jjun/wishlist_funding_frontend/assets/68776394/1c908c49-187b-4835-8621-8e46a44458e3">


## 🏷️ Jira

## 👀 비고
_리뷰어가 참고해야 할 사항이 있으면 적어주세요._
