### PR TITLE
fix: 펀딩 조회 API 관련 로직 수정 (회원, 비회원 구분) / userId, friendId 반대로 된 부분 수정

### DIFF
--- a/src/app/(with-navbar)/fundings/page.suspense.tsx
+++ b/src/app/(with-navbar)/fundings/page.suspense.tsx
@@ -34,7 +34,7 @@ export default function FundingListContent() {
     data: fundingQueryResponse,
     fetchNextPage,
     hasNextPage,
-  } = useFundingsQuery(2, {
+  } = useFundingsQuery({
     fundThemes: themes.map((value) => getFundThemeKey(value)),
     fundPublFilter: getPublFilterKey(visibility),
     status: getFundingStatusKey(status),

--- a/src/app/(with-navbar)/page.suspense.tsx
+++ b/src/app/(with-navbar)/page.suspense.tsx
@@ -50,7 +50,11 @@ export default function MainPageContent() {
             }
           />
         )}
-        <MyFundingSwiper pagination={true} modules={[Pagination]}>
+        <MyFundingSwiper
+          pagination={true}
+          modules={[Pagination]}
+          style={{ width: "100%", height: "100%" }}
+        >
           {myFundingQueryResponse?.pages
             ?.flatMap((page) => page.fundings)
             .map((funding) => (

--- a/src/app/(with-navbar)/page.suspense.tsx
+++ b/src/app/(with-navbar)/page.suspense.tsx
@@ -13,20 +13,17 @@ import { Swiper, SwiperSlide } from "swiper/react";
 import { HorizontalImgCard, VerticalImgCard } from "@/components/card";
 import calculatePercent from "@/utils/calculatePercent";
 import styled from "@emotion/styled";
-import { useEffect } from "react";
-import Cookies from "js-cookie";
 
 export default function MainPageContent() {
   const router = useRouter();
 
-  // TODO: user 기능이 추가되면 useMyFundingQuery와 useFundingsQuery에 전달하는 userId 수정 필요
   // 나의 펀딩
-  const { data: myFundingQueryResponse } = useFundingsQuery(1, {
+  const { data: myFundingQueryResponse } = useFundingsQuery({
     fundPublFilter: "mine",
   });
 
   // 다른 사람들의 펀딩
-  const { data: othersFundingQueryResponse } = useFundingsQuery(2, {
+  const { data: othersFundingQueryResponse } = useFundingsQuery({
     fundPublFilter: "both",
     limit: 5,
   });

--- a/src/app/(with-navbar)/profile/[userId]/page.suspense.tsx
+++ b/src/app/(with-navbar)/profile/[userId]/page.suspense.tsx
@@ -6,6 +6,7 @@ import useFundingsQuery from "@/query/useFundingsQuery";
 import UserProfile from "./view/UserProfile";
 import { FundingList } from "./view/FundingList";
 import useCurrentUserQuery from "@/query/useCurrentUserQuery";
+import { useCookie } from "@/hook/useCookie";
 
 interface Params {
   params: {
@@ -14,24 +15,26 @@ interface Params {
 }
 
 export default function MyPageContent({ params }: Params) {
-  // TODO: 현재 로그인되어 있는 userId로 수정 필요
-  const userId = Number(params.userId);
-  // TODO: 접속한 친구 프로필 페이지의 userId로 수정 필요(friendId)
-  const friendId = 1;
+  const myId = useCookie<number>("userId");
+  const friendId = Number(params.userId);
 
   const [tab, setTab] = useState<FundingStatusValue>("진행 중");
 
   const { data: user } = useCurrentUserQuery();
 
-  const { data: ongoingFundingsQueryResponse } = useFundingsQuery(1, {
-    fundPublFilter: "mine",
-    status: "ongoing",
-  });
+  const { data: ongoingFundingsQueryResponse } = useFundingsQuery(
+    {
+      status: "ongoing",
+    },
+    friendId,
+  );
 
-  const { data: endedFundingsQueryResponse } = useFundingsQuery(1, {
-    fundPublFilter: "mine",
-    status: "ended",
-  });
+  const { data: endedFundingsQueryResponse } = useFundingsQuery(
+    {
+      status: "ended",
+    },
+    friendId,
+  );
 
   const handleTabChange = (
     event: SyntheticEvent,
@@ -47,7 +50,7 @@ export default function MyPageContent({ params }: Params) {
 
   return (
     <>
-      <UserProfile user={user} userId={userId} friendId={friendId} />
+      <UserProfile user={user} userId={myId} friendId={friendId} />
       <StickyTabs
         tabs={[
           {

--- a/src/app/(with-navbar)/profile/[userId]/view/UserProfile.tsx
+++ b/src/app/(with-navbar)/profile/[userId]/view/UserProfile.tsx
@@ -7,7 +7,7 @@ import MyProfileImage from "./MyProfileImage";
 
 interface Props {
   user: UserDto;
-  userId: number;
+  userId: number | undefined;
   friendId: number;
 }
 
@@ -17,13 +17,15 @@ export default function UserProfile({ user, userId, friendId }: Props) {
       <UserInfoContainer direction="column" spacing={2}>
         <Box>
           <UserName variant="h6">{user?.userNick ?? "sample_id"}</UserName>
-          <FriendCount userId={userId} />
+          <FriendCount userId={friendId} />
         </Box>
-        <FriendActionButton
-          userId={userId}
-          userNick={user?.userNick}
-          friendId={friendId}
-        />
+        {userId && (
+          <FriendActionButton
+            userId={userId}
+            userNick={user?.userNick}
+            friendId={friendId}
+          />
+        )}
       </UserInfoContainer>
       <MyProfileImage user={user} />
     </UserProfileContainer>

--- a/src/hook/useCookie.ts
+++ b/src/hook/useCookie.ts
@@ -1,8 +1,8 @@
 import { useEffect, useState } from "react";
 import Cookies from "js-cookie";
 
-export const useCookie = <T = string>(key: string): T | null => {
-  const [cookieValue, setCookieValue] = useState<T | null>(null);
+export const useCookie = <T = string>(key: string): T | undefined => {
+  const [cookieValue, setCookieValue] = useState<T | undefined>(undefined);
 
   useEffect(() => {
     if (typeof window !== "undefined") {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,11 +2,53 @@ import { NextRequest, NextResponse, userAgent } from "next/server";
 
 export function middleware(request: NextRequest) {
   const response = NextResponse.next();
+
   if (!request.cookies.has("viewport")) {
     const { device } = userAgent(request);
     const viewport = device.type === "mobile" ? "mobile" : "desktop";
     response.cookies.set("viewport", viewport);
     response.headers.set("viewport", viewport);
   }
+
+  const accessToken = request.cookies.get("access_token");
+  const userCookie = request.cookies.get("user");
+
+  const userId = getUserIdFromCookie(userCookie?.value);
+  if (userId) {
+    response.cookies.set("userId", userId.toString());
+  }
+
+  if (!accessToken && shouldCheckAuth(request)) {
+    return NextResponse.redirect(new URL("/login", request.url));
+  }
+
+  if (accessToken) {
+    response.cookies.set("isLoggedIn", "true");
+  }
+
   return response;
+}
+
+function getUserIdFromCookie(
+  userCookie: string | undefined,
+): number | undefined {
+  if (!userCookie) return undefined;
+
+  try {
+    const userValue = userCookie.startsWith("j:")
+      ? userCookie.slice(2)
+      : userCookie;
+    const userObj = JSON.parse(userValue);
+    return userObj.userId;
+  } catch (error) {
+    console.error("Failed to parse user cookie", error);
+    return undefined;
+  }
+}
+
+function shouldCheckAuth(request: NextRequest): boolean {
+  const protectedRoutes = ["/setting", "/notification"];
+  return protectedRoutes.some((route) =>
+    request.nextUrl.pathname.startsWith(route),
+  );
 }


### PR DESCRIPTION
## 📝 PR 설명
* AuthGuard가 적용되면서 펀딩 조회 API가 수정된 부분을 반영했습니다.
    * 쿠키에 `userId` 값이 있는지에 따라 로그인 여부를 구분하여 각기 다른 API로 요청을 보내도록 수정했습니다. 
* 프로필 조회 페이지에서 `userId`와 `friendId`가 반대로 설정되어 있는 부분이 있어서 수정했습니다.
    * 좀 더 의미가 명확하게 와닿을 수 있도록 `userId` 변수명을 `myId`로 수정했습니다.
      
## 🏷️ Jira

## 👀 비고
_리뷰어가 참고해야 할 사항이 있으면 적어주세요._
* `userId` 값이 필요한 경우 `useCookie<number>("userId");`와 같은 형태로 사용하시면 됩니다.