### PR TITLE
🐞 fix: NavBar Profile 경로 수정 / 모든 프로필 페이지에서 로그인한 유저 프로필 정보가 보이는 문제 해결

### DIFF
--- a/src/app/(with-navbar)/profile/[userId]/page.suspense.tsx
+++ b/src/app/(with-navbar)/profile/[userId]/page.suspense.tsx
@@ -7,6 +7,7 @@ import UserProfile from "./view/UserProfile";
 import { FundingList } from "./view/FundingList";
 import useCurrentUserQuery from "@/query/useCurrentUserQuery";
 import { useCookie } from "@/hook/useCookie";
+import useUserQuery from "@/query/useUserQuery";
 
 interface Params {
   params: {
@@ -20,7 +21,8 @@ export default function MyPageContent({ params }: Params) {
 
   const [tab, setTab] = useState<FundingStatusValue>("진행 중");
 
-  const { data: user } = useCurrentUserQuery();
+  const { data: loginUser } = useCurrentUserQuery();
+  const { data: anotherUser } = useUserQuery(friendId);
 
   const { data: ongoingFundingsQueryResponse } = useFundingsQuery(
     {
@@ -43,14 +45,21 @@ export default function MyPageContent({ params }: Params) {
     setTab(newTab);
   };
 
-  if (!user) {
+  if (!loginUser) {
     // TODO: fallback UI 작업 필요
+    return null;
+  }
+
+  const profileUser = friendId === myId ? loginUser : anotherUser;
+
+  if (!profileUser) {
+    // TODO: 유저정보가 없을 때
     return null;
   }
 
   return (
     <>
-      <UserProfile user={user} userId={myId} friendId={friendId} />
+      <UserProfile user={profileUser} userId={myId} friendId={friendId} />
       <StickyTabs
         tabs={[
           {

--- a/src/app/(with-navbar)/profile/[userId]/view/MyProfileImage.tsx
+++ b/src/app/(with-navbar)/profile/[userId]/view/MyProfileImage.tsx
@@ -1,9 +1,9 @@
 import { ProfileImage } from "@/components/avatar";
 import useUpdateUser from "@/query/useUpdateUser";
-import { UserDto } from "@/types/User";
+import { User, UserDto } from "@/types/User";
 
 interface Props {
-  user: UserDto;
+  user: User | UserDto;
 }
 
 export default function MyProfileImage({ user }: Props) {
@@ -17,7 +17,7 @@ export default function MyProfileImage({ user }: Props) {
 
   return (
     <ProfileImage
-      imgSrc={user.userImg}
+      imgSrc={user?.userImg}
       onSubmit={handleProfileImageChange}
       userId={user.userId}
     />

--- a/src/app/(with-navbar)/profile/[userId]/view/UserProfile.tsx
+++ b/src/app/(with-navbar)/profile/[userId]/view/UserProfile.tsx
@@ -1,12 +1,12 @@
 import { Box, Stack, Typography } from "@mui/material";
 import { styled } from "@mui/system";
-import { UserDto } from "@/types/User";
+import { User, UserDto } from "@/types/User";
 import FriendActionButton from "./FriendActionButton";
 import FriendCount from "./FriendCount";
 import MyProfileImage from "./MyProfileImage";
 
 interface Props {
-  user: UserDto;
+  user: User | UserDto;
   userId: number | undefined;
   friendId: number;
 }

--- a/src/components/layout/navbar/index.tsx
+++ b/src/components/layout/navbar/index.tsx
@@ -10,11 +10,11 @@ import AccountCircleOutlinedIcon from "@mui/icons-material/AccountCircleOutlined
 import SettingsOutlinedIcon from "@mui/icons-material/SettingsOutlined";
 import { StyledNavigationPaper } from "@/components/layout/navbar/navigation-paper";
 import { StyledBottomNavigation } from "@/components/layout/navbar/bottom-navigation";
+import { useCookie } from "@/hook/useCookie";
 
 export default function NavigationBar() {
   const router = useRouter();
-  // TODO: 로그인한 userId로 수정 필요
-  const userId: number = 1;
+  const loginUserId = useCookie<number>("userId");
   const [tab, setTab] = useState("home");
 
   // 모바일 사이트에서 접속했는지 / 앱에서 접속했는지 여부
@@ -49,7 +49,7 @@ export default function NavigationBar() {
         <BottomNavigationAction
           value="profile"
           icon={<AccountCircleOutlinedIcon />}
-          onClick={() => router.push(`/profile/${userId}`)}
+          onClick={() => router.push(`/profile/${loginUserId}`)}
         />
         <BottomNavigationAction
           value="setting"

--- a/src/components/layout/navbar/index.tsx
+++ b/src/components/layout/navbar/index.tsx
@@ -14,7 +14,7 @@ import { useCookie } from "@/hook/useCookie";
 
 export default function NavigationBar() {
   const router = useRouter();
-  const loginUserId = useCookie<number>("userId");
+  const loginUserId = useCookie<Number>("userId");
   const [tab, setTab] = useState("home");
 
   // 모바일 사이트에서 접속했는지 / 앱에서 접속했는지 여부

--- a/src/types/User.ts
+++ b/src/types/User.ts
@@ -25,6 +25,7 @@ export interface User {
   addresses: AddressDto[];
   defaultImgId?: number;
   image: Image;
+  userImg?: string;
 }
 
 export interface UserDto {


### PR DESCRIPTION
## 📝 PR 설명
- 네이게이션바에 있는 프로필 클릭 시 userId=1로 지정해놓은 부분을 수정하였습니다. (userId를 Cookie에서 받아오도록)
- 모든 프로필 페이지에서 로그인한 유저 프로필로 보이는 문제를 해결하였습니다. (anotherUser는 useUserQuery 사용)

## 🏷️ Jira
[WISH-299](https://wishfund.atlassian.net/browse/WISH-299)

## 👀 비고
[WIP: Local changes before cherry-pick](https://github.com/coding-jjun/wishlist_funding_frontend/commit/ba0ac7fd8211886e292185bf0c69426eef024a41)
요 부분 커밋메세지를 잘못 작성해서 올려버렸습니다 ㅜ.ㅜ
친구 프로필 페이지도 로그인한 유저 정보가 보이는 부분을 수정한 커밋입니다.

[WISH-299]: https://wishfund.atlassian.net/browse/WISH-299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ