### PR TITLE
✨ Feat: 내용이 비어있는 페이지용 공용 컴포넌트 제작

### DIFF
--- a/src/app/(with-navbar)/profile/[userId]/friends/page.tsx
+++ b/src/app/(with-navbar)/profile/[userId]/friends/page.tsx
@@ -12,6 +12,8 @@ import { FriendQueryDto } from "@/types/Friend";
 import { useRouter, useSearchParams } from "next/navigation";
 import Appbar from "@/components/layout/appbar/appbar";
 import DeleteFriendButton from "@/app/(with-navbar)/profile/[userId]/friends/view/DeleteFriendButton";
+import PersonSearchIcon from "@mui/icons-material/PersonSearch";
+import EmptyState from "@/components/emptyState/EmptyState";
 
 interface Params {
   params: {
@@ -26,30 +28,45 @@ export default function FriendsListPage({ params }: Params) {
   const userNick = searchParams.get("userNick");
   const { data: friendsList } = useFriendsQuery(userId);
 
+  if (!friendsList) {
+    return <></>;
+  }
+
   return (
     <>
       <Appbar title={userNick || ""} />
       <Box>
         <List>
-          {friendsList?.result.map((friend: FriendQueryDto) => (
-            <ListItem
-              key={friend.userId}
-              sx={{ marginBottom: 2 }}
-              onClick={() => router.push(`/profile/${friend.userId}`)}
-            >
-              <ListItemAvatar>
-                <Avatar
-                  src={friend.userImg ?? "/dummy/profile.webp"}
-                  sx={{ width: 30, height: 30 }}
+          {friendsList.result ? (
+            friendsList.result.map((friend: FriendQueryDto) => (
+              <ListItem
+                key={friend.userId}
+                sx={{ marginBottom: 2 }}
+                onClick={() => router.push(`/profile/${friend.userId}`)}
+              >
+                <ListItemAvatar>
+                  <Avatar
+                    src={friend.userImg ?? "/dummy/profile.webp"}
+                    sx={{ width: 30, height: 30 }}
+                  />
+                </ListItemAvatar>
+                <ListItemText primary={friend.userName} />
+                <DeleteFriendButton
+                  friendId={friend.userId}
+                  friendName={friend.userName}
                 />
-              </ListItemAvatar>
-              <ListItemText primary={friend.userName} />
-              <DeleteFriendButton
-                friendId={friend.userId}
-                friendName={friend.userName}
-              />
-            </ListItem>
-          ))}
+              </ListItem>
+            ))
+          ) : (
+            <EmptyState
+              icon={
+                <PersonSearchIcon sx={{ fontSize: 60, color: "#FFC107" }} />
+              }
+              title={"앗, 아직 친구가 없어요"}
+              message={"친구 목록을 불러올 수 있는 항목이 없습니다."}
+              buttonText={"확인"}
+            />
+          )}
         </List>
       </Box>
     </>

--- a/src/app/(with-navbar)/profile/[userId]/page.suspense.tsx
+++ b/src/app/(with-navbar)/profile/[userId]/page.suspense.tsx
@@ -26,19 +26,29 @@ export default function MyPageContent({ params }: Params) {
   const { data: loginUser } = useCurrentUserQuery();
   const { data: anotherUser } = useUserQuery(friendId);
 
-  const { data: ongoingFundingsQueryResponse } = useFundingsQuery(
-    {
-      status: "ongoing",
-    },
-    friendId,
-  );
+  // 나의 펀딩 - 진행중
+  const { data: ongoinMyFundingQueryResponse } = useFundingsQuery({
+    fundPublFilter: "mine",
+    status: "ongoing",
+  });
 
-  const { data: endedFundingsQueryResponse } = useFundingsQuery(
-    {
-      status: "ended",
-    },
-    friendId,
-  );
+  // 나의 펀딩 - 종료됨
+  const { data: endedMyFundingQueryResponse } = useFundingsQuery({
+    fundPublFilter: "mine",
+    status: "ended",
+  });
+
+  // 다른 사람들의 펀딩 - 진행중
+  const { data: ongoingOthersFundingQueryResponse } = useFundingsQuery({
+    fundPublFilter: "both",
+    status: "ongoing",
+  });
+
+  // 다른 사람들의 펀딩 - 종료됨
+  const { data: endedOthersFundingQueryResponse } = useFundingsQuery({
+    fundPublFilter: "both",
+    status: "ended",
+  });
 
   const handleTabChange = (
     event: SyntheticEvent,
@@ -51,7 +61,16 @@ export default function MyPageContent({ params }: Params) {
     router.push("/login");
   }
 
+  // 프로필 유저 정보
   const profileUser = friendId === myId ? loginUser : anotherUser;
+  const profileOngoingQuery =
+    friendId === myId
+      ? ongoinMyFundingQueryResponse
+      : ongoingOthersFundingQueryResponse;
+  const profileEndedQuery =
+    friendId === myId
+      ? endedMyFundingQueryResponse
+      : endedOthersFundingQueryResponse;
 
   if (!profileUser) {
     // TODO: 유저정보가 없을 때
@@ -65,14 +84,13 @@ export default function MyPageContent({ params }: Params) {
         tabs={[
           {
             label: `진행 중  ${
-              ongoingFundingsQueryResponse?.pages?.flatMap(
-                (page) => page.fundings,
-              ).length ?? 0
+              profileOngoingQuery?.pages?.flatMap((page) => page.fundings)
+                .length ?? 0
             }     `,
             value: "진행 중",
             panel: (
               <FundingList
-                fundings={ongoingFundingsQueryResponse?.pages?.flatMap(
+                fundings={profileOngoingQuery?.pages?.flatMap(
                   (page) => page.fundings,
                 )}
               />
@@ -80,14 +98,13 @@ export default function MyPageContent({ params }: Params) {
           },
           {
             label: `종료됨  ${
-              endedFundingsQueryResponse?.pages?.flatMap(
-                (page) => page.fundings,
-              ).length ?? 0
+              profileEndedQuery?.pages?.flatMap((page) => page.fundings)
+                .length ?? 0
             }     `,
             value: "종료됨",
             panel: (
               <FundingList
-                fundings={endedFundingsQueryResponse?.pages?.flatMap(
+                fundings={profileEndedQuery?.pages?.flatMap(
                   (page) => page.fundings,
                 )}
               />

--- a/src/app/(with-navbar)/setting/address/[addrId]/page.tsx
+++ b/src/app/(with-navbar)/setting/address/[addrId]/page.tsx
@@ -42,7 +42,6 @@ export default function AddressEditPage({
         </Typography>
       </TopFixedStack>
       <EditAddress
-        userId={1}
         address={address}
         onClose={() => router.push("/setting/address")}
       />

--- a/src/app/(without-navbar)/fundings/[fundId]/page.tsx
+++ b/src/app/(without-navbar)/fundings/[fundId]/page.tsx
@@ -11,6 +11,7 @@ import { currentFundingAtom } from "@/store/atoms/funding";
 import { DetailActionBar } from "@/components/layout/action-bar";
 import { useRouter } from "next/navigation";
 import Appbar from "@/components/layout/appbar/appbar";
+import { useCookie } from "@/hook/useCookie";
 
 export default function FundingDetailPage({
   params,
@@ -21,17 +22,16 @@ export default function FundingDetailPage({
 
   const setCurrentFunding = useSetRecoilState(currentFundingAtom);
   const [isWriter, setIsWriter] = useState<boolean>(false);
-  // TODO: 로그인한 유저 아이디로 수정 필요
-  const currentUser = 1;
+  const loginUserId = useCookie<number>("userId");
 
   const router = useRouter();
 
   useEffect(() => {
     setCurrentFunding(funding);
-    if (currentUser) {
-      setIsWriter(currentUser === 1);
+    if (loginUserId) {
+      setIsWriter(loginUserId === funding?.fundUserId);
     }
-  }, [setCurrentFunding, funding, currentUser]);
+  }, [setCurrentFunding, funding, loginUserId]);
 
   const handleEdit = () => {
     router.push(`/fundings/${params.fundId}/edit`);
@@ -62,6 +62,7 @@ export default function FundingDetailPage({
           {!isWriter && (
             <DetailActionBar
               buttonText="선물하기"
+              // TODO: 후원 페이지 추가 필요
               handleSubmit={() => router.push(``)}
             />
           )}

--- a/src/app/(without-navbar)/fundings/creation/page.tsx
+++ b/src/app/(without-navbar)/fundings/creation/page.tsx
@@ -26,9 +26,8 @@ const DEFAULT_CREATE_GIFT_DTO: GiftDto = {
   id: 1,
   giftOrd: 1,
   giftImg: null,
+  giftTitle: "",
   giftUrl: "",
-  giftOpt: "",
-  giftCont: "",
 };
 
 function getInitialGifts() {

--- a/src/app/(without-navbar)/notification/page.tsx
+++ b/src/app/(without-navbar)/notification/page.tsx
@@ -9,6 +9,7 @@ import {
   Typography,
 } from "@mui/material";
 import ArrowBackIosNewIcon from "@mui/icons-material/ArrowBackIosNew";
+import NotificationsOffIcon from "@mui/icons-material/NotificationsOff";
 import React, { useState } from "react";
 import { useRouter } from "next/navigation";
 import FilterButtonGroup from "@/components/theme/components/FilterButtonGroup";
@@ -20,6 +21,7 @@ import {
 } from "@/types/Notification.enum";
 import useIntersectionObserver from "@/hook/useIntersectionObserver";
 import NotificationWrapper from "@/app/(without-navbar)/notification/view/NotificationWrapper";
+import EmptyState from "@/components/emptyState/EmptyState";
 
 export default function AlarmHistoryPage() {
   const router = useRouter();
@@ -112,7 +114,14 @@ export default function AlarmHistoryPage() {
                 />
               ))
           ) : (
-            <Typography>알림이 없어요</Typography>
+            <EmptyState
+              icon={
+                <NotificationsOffIcon sx={{ fontSize: 60, color: "#FFC107" }} />
+              }
+              title={"앗, 아직 도착한 알림이 없어요"}
+              message={"새로운 소식이 도착하면 알려드릴게요!"}
+              buttonText={"홈으로 가기"}
+            />
           )}
           <div
             ref={observerRef}

--- a/src/components/card/HorizontalDonationCard.tsx
+++ b/src/components/card/HorizontalDonationCard.tsx
@@ -88,7 +88,6 @@ export default function HorizontalDonationCard({
         variant="contained"
         fullWidth
         disableElevation
-        color="grey"
         sx={{ backgroundColor: grey[300], color: grey[900] }}
       >
         {buttonText}

--- a/src/components/dragndrop/DragGifts.tsx
+++ b/src/components/dragndrop/DragGifts.tsx
@@ -68,9 +68,8 @@ export default function DragGifts({ gifts, setGifts }: Props) {
           id: newId,
           giftOrd: currentGifts.length + 1,
           giftImg: null,
+          giftTitle: "",
           giftUrl: "",
-          giftOpt: "",
-          giftCont: "",
         },
       ];
     });

--- a/src/components/dragndrop/GiftItem.tsx
+++ b/src/components/dragndrop/GiftItem.tsx
@@ -165,8 +165,29 @@ export default function GiftItem({
             }}
           />
           <TextField
+            {...register(`gifts[${index - 1}].giftTitle`, {
+              required: "제목을 입력해주세요.",
+            })}
+            helperText={
+              giftsErrors?.[index - 1]?.giftTitle?.message?.toString() || ""
+            }
+            placeholder="제목"
+            size="small"
+            fullWidth
+            margin="dense"
+            InputLabelProps={{ shrink: true }}
+            sx={{
+              borderRadius: 4,
+              backgroundColor: "#ECF0EF",
+              "& .MuiFormHelperText-root": {
+                color: "#d32f2f",
+                pb: "2px",
+              },
+            }}
+          />
+          <TextField
             {...register(`gifts[${index - 1}].giftOpt`)}
-            placeholder="제품 옵션"
+            placeholder="옵션"
             size="small"
             fullWidth
             margin="dense"
@@ -186,7 +207,7 @@ export default function GiftItem({
             helperText={
               giftsErrors?.[index - 1]?.giftCont?.message?.toString() || ""
             }
-            placeholder="상품 설명"
+            placeholder="설명"
             size="small"
             fullWidth
             margin="dense"

--- a/src/components/emptyState/EmptyState.tsx
+++ b/src/components/emptyState/EmptyState.tsx
@@ -1,0 +1,70 @@
+import { Box, Button, Typography } from "@mui/material";
+import { useRouter } from "next/navigation";
+import React from "react";
+
+interface Props {
+  icon: React.ReactNode;
+  title: string;
+  message?: string;
+  buttonText: string;
+}
+
+export default function EmptyState({
+  icon,
+  title,
+  message,
+  buttonText,
+}: Props) {
+  const router = useRouter();
+
+  return (
+    <Box
+      sx={{
+        position: "fixed",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 75,
+        textAlign: "center",
+        px: 2,
+      }}
+    >
+      <Box
+        sx={{
+          flex: 1,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        <Box>
+          {icon}
+          <Typography variant="h6" sx={{ mt: 2 }}>
+            {title}
+          </Typography>
+          <Typography sx={{ color: "#757575", mt: 1 }}>{message}</Typography>
+        </Box>
+      </Box>
+
+      <Button
+        variant="contained"
+        color="primary"
+        sx={{
+          position: "fixed",
+          bottom: 75,
+          width: "90%",
+          left: "50%",
+          transform: "translateX(-50%)",
+          borderRadius: "10px",
+        }}
+        onClick={() => router.back()}
+      >
+        {buttonText}
+      </Button>
+    </Box>
+  );
+}

--- a/src/query/useAddressQuery.ts
+++ b/src/query/useAddressQuery.ts
@@ -1,18 +1,18 @@
 import axios from "axios";
 import { useQuery, UseQueryResult } from "@tanstack/react-query";
-import { Address } from "@/types/Address";
+import { AddressDto } from "@/types/Address";
 import { CommonResponse } from "@/types/CommonResponse";
 
-const fetchAddress = async (addrId: number): Promise<Address> => {
-  const response = await axios.get<CommonResponse<Address>>(
+const fetchAddress = async (addrId: number): Promise<AddressDto> => {
+  const response = await axios.get<CommonResponse<AddressDto>>(
     `/api/address/${addrId}`,
   );
 
   return response.data.data;
 };
 
-const useAddressQuery = (addrId: number): UseQueryResult<Address> => {
-  return useQuery<Address>({
+const useAddressQuery = (addrId: number): UseQueryResult<AddressDto> => {
+  return useQuery<AddressDto>({
     queryKey: ["address", addrId],
     queryFn: () => fetchAddress(addrId),
   });

--- a/src/query/useAddressesQuery.ts
+++ b/src/query/useAddressesQuery.ts
@@ -13,7 +13,7 @@ const fetchAddresses = async (): Promise<AddressDto[]> => {
 const useAddressesQuery = (): UseQueryResult<AddressDto[]> => {
   return useQuery<AddressDto[]>({
     queryKey: ["addresses"],
-    queryFn: () => fetchAddresses(),
+    queryFn: fetchAddresses,
   });
 };
 

--- a/src/query/useDeleteAddress.ts
+++ b/src/query/useDeleteAddress.ts
@@ -6,7 +6,9 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 const deleteAddress = async (
   addrId: number,
 ): Promise<CommonResponse<AddressDto>> => {
-  const { data } = await axios.delete(`/api/address/${addrId}`);
+  const { data } = await axios.delete(`/api/address/${addrId}`, {
+    withCredentials: true, // 요청에 쿠키 포함
+  });
 
   return data;
 };

--- a/src/query/useFriendsQuery.ts
+++ b/src/query/useFriendsQuery.ts
@@ -4,8 +4,8 @@ import { CommonResponse } from "@/types/CommonResponse";
 import { FriendQueryDto } from "@/types/Friend";
 
 interface QueryResponse {
-  result: FriendQueryDto[];
-  total: number;
+  result?: FriendQueryDto[];
+  total?: number;
 }
 
 const fetchFriends = async (userId: number): Promise<QueryResponse> => {

--- a/src/types/GiftDto.ts
+++ b/src/types/GiftDto.ts
@@ -2,9 +2,10 @@ export default interface GiftDto {
   id: number;
   giftImg?: string | null;
   giftOrd: number;
+  giftTitle: string;
   giftUrl: string;
-  giftOpt: string;
-  giftCont: string;
+  giftOpt?: string;
+  giftCont?: string;
 }
 
 export interface ResponseGiftDto {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1013,9 +1013,9 @@ callsites@^3.0.0:
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
 
 caniuse-lite@^1.0.30001579:
-  version "1.0.30001594"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001594.tgz#bea552414cd52c2d0c985ed9206314a696e685f5"
-  integrity sha512-VblSX6nYqyJVs8DKFMldE2IVCJjZ225LW00ydtUWwh5hk9IfkTOffO6r8gJNsH0qqqeAF8KrbMYA2VEwTlGW5g==
+  version "1.0.30001674"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001674.tgz"
+  integrity sha512-jOsKlZVRnzfhLojb+Ykb+gyUSp9Xb57So+fAiFlLzzTKpqg8xxSav0e40c8/4F/v9N8QSvrRRaLeVzQbLqomYw==
 
 chalk@^2.4.2:
   version "2.4.2"


### PR DESCRIPTION
## 📝 PR 설명
내역이 비어있는 경우에 사용할 공용 컴포넌트를 제작했습니다.
[적용한 페이지]
- 알림 히스토리 페이지
- 친구 목록 페이지
<img width="353" alt="스크린샷 2024-11-02 오후 1 06 40" src="https://github.com/user-attachments/assets/d262df5f-fc61-4d39-a84c-19daf975e478">
<img width="350" alt="스크린샷 2024-11-01 오전 11 11 42" src="https://github.com/user-attachments/assets/4f5f3299-ba27-4266-b10a-0c9a6505bebd">

## 🏷️ Jira
[WISH-323](https://wishfund.atlassian.net/browse/WISH-323)

## 👀 비고
_리뷰어가 참고해야 할 사항이 있으면 적어주세요._


[WISH-323]: https://wishfund.atlassian.net/browse/WISH-323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ