### PR TITLE
✨ Feat: 알림 페이지 - 읽은 알림/읽지 않은 알림 구분 및 UI 수정

### DIFF
--- a/src/app/(without-navbar)/fundings/[fundId]/view/FundingInfoPanel.tsx
+++ b/src/app/(without-navbar)/fundings/[fundId]/view/FundingInfoPanel.tsx
@@ -20,7 +20,7 @@ export default function FundingInfoPanel({ funding }: Props) {
       {gifts.map((gift, index) => (
         <GiftCard
           key={gift.giftId}
-          title={`선물 ${index}`}
+          title={gift.giftTitle}
           image={gift.giftImg ?? "/dummy/present.png"}
           option={gift.giftOpt}
           content={gift.giftCont}

--- a/src/app/(without-navbar)/fundings/[fundId]/view/FundingThumbnail.tsx
+++ b/src/app/(without-navbar)/fundings/[fundId]/view/FundingThumbnail.tsx
@@ -52,5 +52,7 @@ const ThumbnailSwiper = styled(Swiper)`
     padding: 5px 10px;
     border-radius: 20px;
     border: none;
+    max-width: 52px;
+    margin-left: auto;
   }
 `;

--- a/src/app/(without-navbar)/notification/view/NotificationWrapper.tsx
+++ b/src/app/(without-navbar)/notification/view/NotificationWrapper.tsx
@@ -54,12 +54,16 @@ export default function NotificationWrapper({
         position: "relative",
       }}
     >
-      <Avatar
-        alt={`${sendNick}-profile`}
-        src={sendImg ?? "/dummy/profile.webp"}
-        sx={{ width: 30, height: 30 }}
-        onClick={handleClickUserProfile}
-      />
+      {notiType !== NotiType.FundClose &&
+        notiType !== NotiType.FundAchieve &&
+        notiType !== NotiType.WriteGratitude && (
+          <Avatar
+            alt={`${sendNick}-profile`}
+            src={sendImg ?? "/dummy/profile.webp"}
+            sx={{ width: 30, height: 30 }}
+            onClick={handleClickUserProfile}
+          />
+        )}
       <div style={{ width: "100%" }} onClick={handleClick}>
         <NotificationContent
           sender={sendNick}

--- a/src/app/(without-navbar)/notification/view/NotificationWrapper.tsx
+++ b/src/app/(without-navbar)/notification/view/NotificationWrapper.tsx
@@ -7,15 +7,26 @@ import getTimeAgoText from "@/utils/getTimeAgoText";
 import IncomingFollowButtons from "@/app/(without-navbar)/notification/view/IncomingFollowButtons";
 import { NotiType } from "@/types/Notification.enum";
 import { useRouter } from "next/navigation";
+import useReadNotification from "@/query/useReadNotification";
 
 interface Props {
   notification: Notification;
+  entryTimeRef: React.MutableRefObject<Date>;
 }
 
-export default function NotificationWrapper({ notification }: Props) {
+export default function NotificationWrapper({
+  notification,
+  entryTimeRef,
+}: Props) {
   const router = useRouter();
-  const { sendId, senderImg, sendNick, notiType, subId, notiTime, fundTitle } =
+  const { sendId, sendImg, sendNick, notiType, subId, notiTime, fundTitle } =
     notification;
+  const { mutate: readNoti } = useReadNotification(entryTimeRef.current); // isRead: false -> true
+
+  const handleClickUserProfile = () => {
+    readNoti();
+    router.push(`/profile/${sendId}`);
+  };
 
   const handleClick = () => {
     if (
@@ -23,8 +34,10 @@ export default function NotificationWrapper({ notification }: Props) {
       notiType === NotiType.AcceptFollow ||
       notiType === NotiType.NewFriend
     ) {
+      readNoti();
       router.push(`/profile/${sendId}`);
     } else if (subId) {
+      readNoti();
       router.push(`/fundings/${subId}`);
     }
   };
@@ -36,16 +49,16 @@ export default function NotificationWrapper({ notification }: Props) {
       alignItems="flex-start"
       spacing={2}
       sx={{
-        pb: 3,
+        py: 1.5,
         width: "100%",
         position: "relative",
       }}
     >
       <Avatar
         alt={`${sendNick}-profile`}
-        src={senderImg ?? "/dummy/profile.webp"}
+        src={sendImg ?? "/dummy/profile.webp"}
         sx={{ width: 30, height: 30 }}
-        onClick={() => router.push(`/profile/${sendId}`)}
+        onClick={handleClickUserProfile}
       />
       <div style={{ width: "100%" }} onClick={handleClick}>
         <NotificationContent

--- a/src/components/card/GiftCard.tsx
+++ b/src/components/card/GiftCard.tsx
@@ -24,7 +24,7 @@ export default function GiftCard({
       <Stack
         direction="row"
         spacing={2}
-        alignItems="flex-start"
+        alignItems="center"
         sx={{
           border: "1px solid #e2e2e2",
           p: "10px",
@@ -39,29 +39,22 @@ export default function GiftCard({
         />
         <Stack
           id="content"
+          direction="column"
           justifyContent="space-between"
-          spacing={2}
-          sx={{
-            display: "flex",
-            flexDirection: "column",
-            width: "calc(100% - 120px)",
-            paddingY: "4px",
-          }}
+          spacing={1}
         >
-          <Stack direction="column">
-            <Typography
-              variant="body1"
-              component="div"
-              fontWeight="bold"
-              color={grey[800]}
-              margin="none"
-            >
-              {title}
-            </Typography>
-            <Typography variant="body2" color="text.secondary" margin="none">
-              {option}
-            </Typography>
-          </Stack>
+          <Typography
+            variant="body1"
+            component="div"
+            fontWeight="bold"
+            color={grey[800]}
+            margin="none"
+          >
+            {title}
+          </Typography>
+          <Typography variant="body2" color="text.secondary" margin="none">
+            {option}
+          </Typography>
           <Typography variant="body2" color={grey[600]}>
             {content}
           </Typography>

--- a/src/components/comment/CommentInput.tsx
+++ b/src/components/comment/CommentInput.tsx
@@ -12,12 +12,25 @@ export default function CommentInput({ fundUuid }: Props) {
   const [content, setContent] = useState<string>("");
   const { mutate } = useAddComment(fundUuid);
 
+  const handleSubmit = () => {
+    if (!content.trim()) return;
+    mutate(
+      { content },
+      {
+        onSuccess: () => {
+          setContent("");
+        },
+      },
+    );
+  };
+
   return (
     <OutlinedInput
       placeholder="댓글 등록"
+      value={content}
       endAdornment={
         <InputAdornment position="end" variant="filled">
-          <IconButton onClick={() => mutate({ content })}>
+          <IconButton onClick={handleSubmit}>
             <ArrowCircleUpIcon />
           </IconButton>
         </InputAdornment>

--- a/src/components/progress/ProgressBarWithText.tsx
+++ b/src/components/progress/ProgressBarWithText.tsx
@@ -29,7 +29,8 @@ export default function ProgressBarWithText({
   endDate,
   textSize,
 }: Props) {
-  const progress: number = calculatePercent(fundSum, fundGoal);
+  const sum: number = 200000;
+  const progress: number = calculatePercent(sum, fundGoal);
 
   return (
     <Box sx={{ width: "100%" }}>
@@ -45,20 +46,39 @@ export default function ProgressBarWithText({
           }}
         />
         {/* 달성률 */}
-        <Typography
-          variant="body2"
-          fontWeight={600}
-          color="white"
-          sx={{
-            position: "absolute",
-            top: "50%",
-            left: `${Math.min(100, progress)}%`,
-            transform: "translate(-140%, -50%)",
-            whiteSpace: "nowrap",
-          }}
-        >
-          {`${progress}%`}
-        </Typography>
+        {/* 13% 미만: 미달성한 부분에 달성률 표시*/}
+        {/* 13% 이상: 달성한 부분에 달성률 표시*/}
+        {progress < 13 ? (
+          <Typography
+            variant="body2"
+            fontWeight={600}
+            color="grey"
+            sx={{
+              position: "absolute",
+              top: "50%",
+              left: `${Math.min(100, progress)}%`,
+              transform: "translate(30%, -50%)",
+              whiteSpace: "nowrap",
+            }}
+          >
+            {`${progress}%`}
+          </Typography>
+        ) : (
+          <Typography
+            variant="body2"
+            fontWeight={600}
+            color="white"
+            sx={{
+              position: "absolute",
+              top: "50%",
+              left: `${Math.min(100, progress)}%`,
+              transform: "translate(-140%, -50%)",
+              whiteSpace: "nowrap",
+            }}
+          >
+            {`${progress}%`}
+          </Typography>
+        )}
       </Box>
 
       {/* 남은 금액, 남은 일자 */}

--- a/src/components/progress/ProgressBarWithText.tsx
+++ b/src/components/progress/ProgressBarWithText.tsx
@@ -45,9 +45,9 @@ export default function ProgressBarWithText({
           }}
         />
         {/* 달성률 */}
-        {/* 13% 미만: 미달성한 부분에 달성률 표시*/}
+        {/* 0 이상 13% 미만: 미달성한 부분에 달성률 표시*/}
         {/* 13% 이상: 달성한 부분에 달성률 표시*/}
-        {progress < 13 ? (
+        {0 < progress && progress < 13 ? (
           <Typography
             variant="body2"
             fontWeight={600}

--- a/src/components/progress/ProgressBarWithText.tsx
+++ b/src/components/progress/ProgressBarWithText.tsx
@@ -29,8 +29,7 @@ export default function ProgressBarWithText({
   endDate,
   textSize,
 }: Props) {
-  const sum: number = 200000;
-  const progress: number = calculatePercent(sum, fundGoal);
+  const progress: number = calculatePercent(fundSum, fundGoal);
 
   return (
     <Box sx={{ width: "100%" }}>

--- a/src/types/GiftDto.ts
+++ b/src/types/GiftDto.ts
@@ -13,6 +13,7 @@ export interface ResponseGiftDto {
   fundId: number;
   giftUrl: string;
   giftOrd: number;
+  giftTitle: string;
   giftOpt: string;
   giftCont: string;
   giftImg: string;

--- a/src/types/Notification.enum.ts
+++ b/src/types/Notification.enum.ts
@@ -1,14 +1,14 @@
 import { getKeyByValue } from "@/utils/map";
 
 export enum NotiType {
-  IncomingFollow = "IncomingFollow", // 들어오는 친구 요청
+  IncomingFollow = "IncomingFollow", // 들어온 친구 요청
   AcceptFollow = "AcceptFollow", // 내 요청에 대한 친구의 수락
   FundClose = "FundClose", // 내 펀딩 마감
   FundAchieve = "FundAchieve", // 내 펀딩 달성
   NewDonate = "NewDonate", // 내 펀딩에 들어온 새로운 후원
   WriteGratitude = "WriteGratitude", // 감사인사 작성 권유
   NewComment = "NewComment", // 댓글 알림
-  DonatedFundClose = "DonatedFundClose",
+  DonatedFundClose = "DonatedFundClose", // 후원한 펀딩 마감
   CheckGratitude = "CheckGratitude", // 내가 후원한 펀딩 감사인사 확인
   NewFriend = "NewFriend", // 친구 수락
   DeleteFriend = "DeleteFriend", // 친구 삭제

--- a/src/types/Notification.ts
+++ b/src/types/Notification.ts
@@ -5,11 +5,12 @@ export interface Notification {
   recvId: number;
   sendId: number;
   sendNick: string;
-  senderImg: string;
+  sendImg: string;
   notiType: NotiType;
   subId?: string;
   notiTime: Date;
   fundTitle?: string;
+  isRead: boolean;
 }
 
 export interface NotificationQueryParam {


### PR DESCRIPTION
## 📝 PR 설명
![2024-11-24 GIF from ezgif com](https://github.com/user-attachments/assets/ad3dc3f8-446b-452d-8d6b-d0350404db54)
- 알림 페이지
    - 알림 페이지를 벗어날 때(뒤로가기, 알림 상세 내역으로 이동) readNoti 호출
    - 나와 관련된 알림일 때 프로필 이미지(아바타) 보이지 않도록 수정

## 🏷️ Jira
[WISH-349](https://wishfund.atlassian.net/browse/WISH-349)

## 👀 비고
_리뷰어가 참고해야 할 사항이 있으면 적어주세요._


[WISH-349]: https://wishfund.atlassian.net/browse/WISH-349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ