### PR TITLE
fix: 네비게이션바 내 프로필 페이지 버튼 URL 수정

### DIFF
--- a/src/app/(with-navbar)/setting/action.ts
+++ b/src/app/(with-navbar)/setting/action.ts
@@ -6,19 +6,26 @@ import axiosInstance from "@/utils/axios";
 export async function logout() {
   const cookieStore = await cookies();
 
-  const refreshToken = cookieStore.get("refreshToken");
+  const refreshToken = cookieStore.get("refresh_token");
 
   if (refreshToken) {
-    const { data } = await axiosInstance.post("/api/auth/logout", {
-      refreshToken: refreshToken,
-    });
-
-    if (data?.data) {
-      cookieStore.delete("access_token");
-      cookieStore.delete("refreshToken");
-      cookieStore.delete("userId");
-      cookieStore.delete("nickname");
-      redirect("/");
+    try {
+      const { data } = await axiosInstance.post(
+        "https://api.giftogether.co.kr/auth/logout",
+        {
+          refreshToken: refreshToken.value,
+        },
+      );
+      if (data?.data) {
+        cookieStore.delete("access_token");
+        cookieStore.delete("refresh_token");
+        cookieStore.delete("userId");
+        cookieStore.delete("nickname");
+        redirect("/");
+      }
+    } catch (e) {
+      console.error(e);
+      throw new Error("로그아웃 실패");
     }
   }
 }

--- a/src/app/server/login/route.ts
+++ b/src/app/server/login/route.ts
@@ -45,7 +45,7 @@ export async function POST(request: Request): Promise<NextResponse> {
       httpOnly: false,
       expires,
     });
-    res.cookies.set("refreshToken", refreshToken, cookieOptions);
+    res.cookies.set("refresh_token", refreshToken, cookieOptions);
     res.cookies.set("userId", tokenPayload.sub, {
       ...cookieOptions,
       httpOnly: false,

--- a/src/app/server/login/route.ts
+++ b/src/app/server/login/route.ts
@@ -46,7 +46,11 @@ export async function POST(request: Request): Promise<NextResponse> {
       expires,
     });
     res.cookies.set("refreshToken", refreshToken, cookieOptions);
-    res.cookies.set("userId", tokenPayload.sub, { ...cookieOptions, expires });
+    res.cookies.set("userId", tokenPayload.sub, {
+      ...cookieOptions,
+      httpOnly: false,
+      expires,
+    });
 
     if (user?.userNick) {
       res.cookies.set("nickname", user.userNick, { ...cookieOptions, expires });

--- a/src/components/layout/layout-with-logo/NavigationBar.tsx
+++ b/src/components/layout/layout-with-logo/NavigationBar.tsx
@@ -1,58 +1,10 @@
-"use client";
-import Link from "next/link";
-import { usePathname } from "next/navigation";
-import HomeIcon from "@public/icons/Home.svg";
-import PeopleIcon from "@public/icons/People.svg";
-import AddIcon from "@public/icons/AddCircle.svg";
-import AccountIcon from "@public/icons/Account.svg";
-import SettingsIcon from "@public/icons/Settings.svg";
-import { activeIcon, icon, iconBtn, navBar } from "./layout.css";
-
-const NAVIGATIONS = [
-  {
-    href: "/",
-    icon: HomeIcon,
-  },
-  {
-    href: "/fundings",
-    icon: PeopleIcon,
-  },
-  {
-    href: "/fundings/creation",
-    icon: AddIcon,
-  },
-  {
-    href: "/profile",
-    icon: AccountIcon,
-  },
-  {
-    href: "/setting",
-    icon: SettingsIcon,
-  },
-];
-
-interface Props {
-  href: string;
-  SvgIcon: React.FunctionComponent<React.SVGProps<SVGSVGElement>>;
-}
-
-const NavigationButton = ({ href, SvgIcon }: Props) => {
-  const pathname = usePathname();
-  const isActive = pathname === href;
-
-  return (
-    <Link href={href} className={iconBtn}>
-      <SvgIcon className={`${icon} ${isActive ? activeIcon : ""}`} />
-    </Link>
-  );
-};
+"use server";
+import { cookies } from "next/headers";
+import { NavigationButtons } from "@/components/layout/layout-with-logo/NavigationButtons";
 
 export const NavigationBar = () => {
-  return (
-    <div className={navBar}>
-      {NAVIGATIONS.map((nav) => (
-        <NavigationButton key={nav.href} href={nav.href} SvgIcon={nav.icon} />
-      ))}
-    </div>
-  );
+  const cookieStore = cookies();
+  const userId = cookieStore.get("userId")?.value;
+
+  return <NavigationButtons userId={userId} />;
 };

--- a/src/components/layout/layout-with-logo/NavigationButtons.tsx
+++ b/src/components/layout/layout-with-logo/NavigationButtons.tsx
@@ -1,0 +1,62 @@
+"use client";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import HomeIcon from "@public/icons/Home.svg";
+import PeopleIcon from "@public/icons/People.svg";
+import AddIcon from "@public/icons/AddCircle.svg";
+import AccountIcon from "@public/icons/Account.svg";
+import SettingsIcon from "@public/icons/Settings.svg";
+import { activeIcon, icon, iconBtn, navBar } from "./layout.css";
+
+interface NavigationButtonProps {
+  href: string;
+  SvgIcon: React.FunctionComponent<React.SVGProps<SVGSVGElement>>;
+}
+
+const NavigationButton = ({ href, SvgIcon }: NavigationButtonProps) => {
+  const pathname = usePathname();
+  const isActive = pathname === href;
+
+  return (
+    <Link href={href} className={iconBtn}>
+      <SvgIcon className={`${icon} ${isActive ? activeIcon : ""}`} />
+    </Link>
+  );
+};
+
+interface ClientNavigationBarProps {
+  userId: string | undefined;
+}
+
+export const NavigationButtons = ({ userId }: ClientNavigationBarProps) => {
+  const NAVIGATIONS = [
+    {
+      href: "/",
+      icon: HomeIcon,
+    },
+    {
+      href: "/fundings",
+      icon: PeopleIcon,
+    },
+    {
+      href: "/fundings/creation",
+      icon: AddIcon,
+    },
+    {
+      href: `/profile/${userId}`,
+      icon: AccountIcon,
+    },
+    {
+      href: "/setting",
+      icon: SettingsIcon,
+    },
+  ];
+
+  return (
+    <div className={navBar}>
+      {NAVIGATIONS.map((nav) => (
+        <NavigationButton key={nav.href} href={nav.href} SvgIcon={nav.icon} />
+      ))}
+    </div>
+  );
+};


### PR DESCRIPTION
## 📝 PR 설명
* 클라이언트에서 `userId` 쿠키 값에 접근이 필요한 경우가 있어서 httpOnly 옵션을 false로 변경했습니다.
* 하단 네비게이션바의 URL을 `/profile`에서 `/profile/${userId 쿠키 값}`으로 변경했습니다.
* 로그아웃 서버 액션에서 refresh token 쿠키 값을 잘못 읽어오는 에러를 수정했습니다.
* 리프레쉬 토큰 쿠키명을 백엔드와 동일하게 `refresh_token`으로 수정했습니다.

## 🏷️ Jira
[WISH-405](https://wishfund.atlassian.net/browse/WISH-405)

## 👀 비고
_리뷰어가 참고해야 할 사항이 있으면 적어주세요._


[WISH-405]: https://wishfund.atlassian.net/browse/WISH-405?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ