### PR TITLE
fix: 로그아웃 시 발생하는 "토큰이 없습니다" 에러 수정 / `middleware.ts` 수정

### DIFF
--- a/src/app/(with-navbar)/setting/action.ts
+++ b/src/app/(with-navbar)/setting/action.ts
@@ -9,11 +9,21 @@ export async function logout() {
   const refreshToken = cookieStore.get("refresh_token");
 
   if (refreshToken) {
+    const cookieHeader = cookieStore
+      .getAll()
+      .map((cookie) => `${cookie.name}=${cookie.value}`)
+      .join("; ");
+
     try {
       const { data } = await axiosInstance.post(
         "https://api.giftogether.co.kr/auth/logout",
         {
           refreshToken: refreshToken.value,
+        },
+        {
+          headers: {
+            Cookie: cookieHeader,
+          },
         },
       );
       if (data?.data) {
@@ -21,11 +31,12 @@ export async function logout() {
         cookieStore.delete("refresh_token");
         cookieStore.delete("userId");
         cookieStore.delete("nickname");
-        redirect("/");
       }
     } catch (e) {
       console.error(e);
       throw new Error("로그아웃 실패");
     }
+
+    redirect("/");
   }
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -12,11 +12,14 @@ export async function middleware(request: NextRequest) {
     response.headers.set("viewport", viewport);
   }
 
+  let isAuthorized = false;
   const cookieSession = (await cookies()).get("access_token")?.value;
-  const session = await decrypt(cookieSession);
 
-  const isAuthorized =
-    session && session.exp && session?.exp * 1000 > new Date().getTime();
+  if (cookieSession) {
+    const session = await decrypt(cookieSession);
+    isAuthorized =
+      !!session && !!session.exp && session?.exp * 1000 > new Date().getTime();
+  }
 
   if (!isAuthorized && shouldCheckAuth(request)) {
     return NextResponse.redirect(new URL("/login", request.url));


### PR DESCRIPTION
## 📝 PR 설명
### 로그아웃 에러 수정
* next.js 서버 액션에서 로그아웃 API로 요청을 보내면, "토큰이 없습니다" 에러가 발생했습니다.
* 에러 원인은 서버 환경에서 실행되기 때문에 브라우저에 셋팅된 쿠키가 자동으로 전송되지 않았기 때문입니다.
* cookies API로 쿠키를 가져와서 로그아웃 요청 헤더에 쿠키를 명시적으로 포함하도록 했습니다.
### `middlware.ts` 수정
* 쿠키에 `access_token`이 없는데도 `decrypt` 함수를 실행해서 "Failed to verify session" 에러 로그가 계속 찍히고 있었습니다.
* 쿠키에 `access_token`이 있는 경우에만 `decrypt` 함수를 실행하도록 수정했습니다.

## 🏷️ Jira
[WISH-405](https://wishfund.atlassian.net/browse/WISH-405)

## 👀 비고
_리뷰어가 참고해야 할 사항이 있으면 적어주세요._


[WISH-405]: https://wishfund.atlassian.net/browse/WISH-405?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ