### PR TITLE
fix: `PullToRefresh`로 인해 스크롤이 튕기는 에러 수정

### DIFF
--- a/src/components/refresh/PullToRefresh.tsx
+++ b/src/components/refresh/PullToRefresh.tsx
@@ -9,7 +9,8 @@ interface PullToRefreshProps {
 
 const PullToRefresh = ({ refreshData }: PullToRefreshProps) => {
   const [isRefreshing, setIsRefreshing] = useState(false);
-  const [startScroll, setStartScroll] = useState(0);
+  const [isPulling, setIsPulling] = useState(false);
+  const [startY, setStartY] = useState(0);
 
   const triggerVibration = () => {
     if ("vibrate" in navigator) {
@@ -18,14 +19,10 @@ const PullToRefresh = ({ refreshData }: PullToRefreshProps) => {
   };
 
   useEffect(() => {
-    let startY = 0;
-    let isPulling = false;
-
     const handleTouchStart = (e: TouchEvent) => {
       if (window.scrollY === 0) {
-        startY = e.touches[0].pageY;
-        setStartScroll(window.scrollY);
-        isPulling = true;
+        setStartY(e.touches[0].pageY);
+        setIsPulling(true);
       }
     };
 
@@ -34,6 +31,7 @@ const PullToRefresh = ({ refreshData }: PullToRefreshProps) => {
 
       const currentY = e.touches[0].pageY;
       if (currentY - startY > 100) {
+        e.preventDefault();
         setIsRefreshing(true);
       }
     };
@@ -44,8 +42,7 @@ const PullToRefresh = ({ refreshData }: PullToRefreshProps) => {
         await refreshData();
       }
       setIsRefreshing(false);
-      window.scrollTo({ top: startScroll, behavior: "smooth" });
-      isPulling = false;
+      setIsPulling(false);
     };
 
     window.addEventListener("touchstart", handleTouchStart);
@@ -57,15 +54,15 @@ const PullToRefresh = ({ refreshData }: PullToRefreshProps) => {
       window.removeEventListener("touchmove", handleTouchMove);
       window.removeEventListener("touchend", handleTouchEnd);
     };
-  }, [isRefreshing, refreshData, startScroll]);
+  }, [isPulling, isRefreshing, startY, refreshData]);
 
   return (
     <>
-      {isRefreshing ? (
+      {isRefreshing && (
         <div className={loadingContainer}>
           <DotLottieReact src="/animation/loading.lottie" autoplay loop />
         </div>
-      ) : null}
+      )}
     </>
   );
 };


### PR DESCRIPTION
## 📝 PR 설명
### 스크롤 튕기는 에러 수정
* `PullToRefresh` 컴포넌트로 인해 스크롤이 튕기는 에러를 수정했습니다.
* `isPulling` 값을 React state로 관리하도록 해서 touchstart, touchmove, touchend 이벤트 리스너가 이 값을 공유할 수 있도록 했습니다.
* `handleTouchEnd`에서 `window.scrollTo`를 제거해서 스크롤을 방해하지 않도록 수정했습니다.

## 🏷️ Jira
[WISH-435](https://wishfund.atlassian.net/browse/WISH-435)

## 👀 비고
_리뷰어가 참고해야 할 사항이 있으면 적어주세요._


[WISH-435]: https://wishfund.atlassian.net/browse/WISH-435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ