### PR TITLE
feat: 펀딩 후원 내역 페이지 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@mui/lab": "^5.0.0-alpha.170",
     "@mui/material": "^5.15.11",
     "@mui/x-date-pickers": "^7.2.0",
-    "@tanstack/react-query": "^5.29.2",
+    "@tanstack/react-query": "^5.66.0",
     "@vanilla-extract/css": "^1.16.0",
     "@vanilla-extract/dynamic": "^2.1.2",
     "axios": "^1.6.8",

--- a/src/app/(without-navbar)/fundings/[fundId]/donations/client.tsx
+++ b/src/app/(without-navbar)/fundings/[fundId]/donations/client.tsx
@@ -1,0 +1,69 @@
+"use client";
+import dayjs from "dayjs";
+import { useFundingDonationsQuery } from "@/query/useFundingDonationsQuery";
+import addComma from "@/utils/addComma";
+import useIntersectionObserver from "@/hook/useIntersectionObserver";
+import {
+  amountText,
+  container,
+  dateText,
+  detailsSection,
+  donationItem,
+  emptyMessage,
+  observer,
+  userImage,
+  userName,
+} from "./page.css";
+
+interface Props {
+  fundUuid: string;
+}
+
+export const DonationList = ({ fundUuid }: Props) => {
+  const { data, fetchNextPage, hasNextPage } =
+    useFundingDonationsQuery(fundUuid);
+
+  // 무한 스크롤
+  const loadMore = () => {
+    if (hasNextPage) {
+      fetchNextPage();
+    }
+  };
+
+  // 무한 스크롤 관련 IntersectionObserver 훅
+  const observerRef = useIntersectionObserver(loadMore, {
+    root: null,
+    rootMargin: "0px",
+    threshold: 1.0,
+  });
+
+  if (data?.pages[0]?.donations?.length === 0) {
+    return <div className={emptyMessage}>후원 내역이 없습니다</div>;
+  }
+
+  return (
+    <div className={container}>
+      {data?.pages
+        .flatMap((page) => page.donations)
+        .map((donation) => (
+          <div key={donation.donId} className={donationItem}>
+            <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+              <img
+                src={donation.donUserImg}
+                alt={donation.donUserNick}
+                className={userImage}
+              />
+              <p className={userName}>{donation.donUserNick}</p>
+            </div>
+            <div className={detailsSection}>
+              <p className={dateText}>
+                {dayjs(donation.regAt).format("YYYY.MM.DD")}
+              </p>
+              <p className={amountText}>{addComma(donation.donAmnt)}원</p>
+            </div>
+          </div>
+        ))}
+      <div ref={observerRef} className={observer} />
+    </div>
+  );
+};

--- a/src/app/(without-navbar)/fundings/[fundId]/donations/page.css.ts
+++ b/src/app/(without-navbar)/fundings/[fundId]/donations/page.css.ts
@@ -1,0 +1,65 @@
+import { style } from '@vanilla-extract/css';
+
+export const container = style({
+  padding: '18px',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '12px',
+});
+
+export const emptyMessage = style({
+  height: 'calc(100dvh - 52px)',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  fontSize: '16px',
+});
+
+export const donationItem = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  padding: '12px',
+});
+
+export const userSection = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '8px',
+});
+
+export const userImage = style({
+  width: '50px',
+  height: '50px',
+  borderRadius: '50%',
+  objectFit: 'cover',
+});
+
+export const userName = style({
+  fontSize: '16px',
+  fontWeight: 700,
+  color: '#424242',
+});
+
+export const detailsSection = style({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'flex-end',
+  justifyContent: 'center',
+  gap: '4px',
+});
+
+export const dateText = style({
+  fontSize: '12px',
+  color: '#888888',
+});
+
+export const amountText = style({
+  fontSize: '16px',
+  fontWeight: 700,
+});
+
+export const observer = style({
+  height: '20px',
+  background: 'transparent',
+});

--- a/src/app/(without-navbar)/fundings/[fundId]/donations/page.tsx
+++ b/src/app/(without-navbar)/fundings/[fundId]/donations/page.tsx
@@ -10,14 +10,17 @@ interface DonationsPageProps {
   };
 }
 
-export default function DonationsPage({ params }: DonationsPageProps) {
+export default async function DonationsPage({ params }: DonationsPageProps) {
   const fundUuid = params.fundId;
 
   const queryClient = getQueryClient();
 
-  void queryClient.prefetchQuery({
+  await queryClient.prefetchInfiniteQuery({
     queryKey: ["donations", fundUuid],
     queryFn: () => fetchDonations(fundUuid),
+    initialPageParam: undefined,
+    getNextPageParam: (lastPage) => lastPage.lastId,
+    pages: 1,
   });
 
   return (

--- a/src/app/(without-navbar)/fundings/[fundId]/donations/page.tsx
+++ b/src/app/(without-navbar)/fundings/[fundId]/donations/page.tsx
@@ -1,0 +1,30 @@
+import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
+import { getQueryClient } from "@/utils/react-query";
+import { fetchDonations } from "@/query/useFundingDonationsQuery";
+import { DonationList } from "@/app/(without-navbar)/fundings/[fundId]/donations/client";
+import LayoutWithPrev from "@/components/layout/layout-with-prev";
+
+interface DonationsPageProps {
+  params: {
+    fundId: string;
+  };
+}
+
+export default function DonationsPage({ params }: DonationsPageProps) {
+  const fundUuid = params.fundId;
+
+  const queryClient = getQueryClient();
+
+  void queryClient.prefetchQuery({
+    queryKey: ["donations", fundUuid],
+    queryFn: () => fetchDonations(fundUuid),
+  });
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <LayoutWithPrev title="후원내역">
+        <DonationList fundUuid={params.fundId} />
+      </LayoutWithPrev>
+    </HydrationBoundary>
+  );
+}

--- a/src/app/(without-navbar)/fundings/[fundId]/page.tsx
+++ b/src/app/(without-navbar)/fundings/[fundId]/page.tsx
@@ -16,6 +16,7 @@ import FundUserNick from "@/app/(without-navbar)/fundings/[fundId]/view/FundUser
 import PullToRefresh from "@/components/refresh/PullToRefresh";
 import LayoutWithPrev from "@/components/layout/layout-with-prev";
 import { useToast } from "@/components/toast";
+import { NextLink } from "@/components/link";
 
 export default function FundingDetailPage({
   params,
@@ -48,10 +49,6 @@ export default function FundingDetailPage({
       setIsWriter(loginUserId === funding?.fundUserId);
     }
   }, [setCurrentFunding, funding, loginUserId]);
-
-  const handleEdit = () => {
-    router.push(`/fundings/${params.fundId}/edit`);
-  };
 
   const handleDelete = () => {
     if (params.fundId === "") return;
@@ -122,8 +119,13 @@ export default function FundingDetailPage({
           open={Boolean(anchorEl)}
           onClose={handleMenuClose}
         >
-          <MenuItem onClick={handleEdit}>수정</MenuItem>
+          <NextLink href={`/fundings/${params.fundId}/edit`}>
+            <MenuItem>수정</MenuItem>
+          </NextLink>
           <MenuItem onClick={handleDelete}>삭제</MenuItem>
+          <NextLink href={`/fundings/${params.fundId}/donations`}>
+            <MenuItem>후원내역</MenuItem>
+          </NextLink>
         </Menu>
       )}
       <PullToRefresh refreshData={refetch} />

--- a/src/components/link/index.tsx
+++ b/src/components/link/index.tsx
@@ -1,0 +1,14 @@
+import Link from "next/link";
+
+interface Props {
+  href: string;
+  children: React.ReactNode;
+}
+
+export const NextLink = ({ href, children }: Props) => {
+  return (
+    <Link href={href} style={{ textDecoration: "none" }}>
+      {children}
+    </Link>
+  );
+};

--- a/src/components/provider/QueryClientProvider.tsx
+++ b/src/components/provider/QueryClientProvider.tsx
@@ -1,25 +1,14 @@
 "use client";
-import {
-  QueryClient,
-  QueryClientProvider as ReactQueryClientProvider,
-} from "@tanstack/react-query";
-import { ReactNode, useState } from "react";
+import { ReactNode } from "react";
+import { QueryClientProvider as ReactQueryClientProvider } from "@tanstack/react-query";
+import { getQueryClient } from "@/utils/react-query";
 
 interface Props {
   children: ReactNode;
 }
 
 export default function QueryClientProvider({ children }: Props) {
-  const [queryClient] = useState(
-    () =>
-      new QueryClient({
-        defaultOptions: {
-          queries: {
-            staleTime: 60 * 1000,
-          },
-        },
-      }),
-  );
+  const queryClient = getQueryClient();
 
   return (
     <ReactQueryClientProvider client={queryClient}>

--- a/src/query/useFundingDonationsQuery.ts
+++ b/src/query/useFundingDonationsQuery.ts
@@ -1,0 +1,49 @@
+import {
+  DefaultError,
+  InfiniteData,
+  QueryKey,
+  useInfiniteQuery,
+} from "@tanstack/react-query";
+import axiosInstance from "@/utils/axios";
+import { DonationListDto } from "@/types/Donation";
+
+interface FundingDonationsResponse {
+  donations: DonationListDto[];
+  lastId: number;
+}
+
+interface PageParam {
+  lastId: number | undefined;
+}
+
+export const fetchDonations = async (
+  fundUuid: string,
+  lastId?: number,
+): Promise<FundingDonationsResponse> => {
+  const { data } = await axiosInstance.get(
+    `/api/funding/${fundUuid}/donation`,
+    {
+      params: { lastId },
+    },
+  );
+
+  return data.data;
+};
+
+export const useFundingDonationsQuery = (fundUuid: string) => {
+  return useInfiniteQuery<
+    FundingDonationsResponse,
+    DefaultError,
+    InfiniteData<FundingDonationsResponse>,
+    QueryKey,
+    PageParam
+  >({
+    queryKey: ["donations", fundUuid],
+    queryFn: ({ pageParam = { lastId: undefined } }) =>
+      fetchDonations(fundUuid, pageParam.lastId),
+    getNextPageParam: (lastPage) => {
+      return { lastId: lastPage.lastId };
+    },
+    initialPageParam: { lastId: undefined },
+  });
+};

--- a/src/query/useFundingDonationsQuery.ts
+++ b/src/query/useFundingDonationsQuery.ts
@@ -4,21 +4,19 @@ import {
   QueryKey,
   useInfiniteQuery,
 } from "@tanstack/react-query";
-import axiosInstance from "@/utils/axios";
 import { DonationListDto } from "@/types/Donation";
+import axiosInstance from "@/utils/axios";
 
 interface FundingDonationsResponse {
   donations: DonationListDto[];
-  lastId: number;
+  lastId?: number | null;
 }
 
-interface PageParam {
-  lastId: number | undefined;
-}
+type PageParam = number | undefined | null;
 
 export const fetchDonations = async (
   fundUuid: string,
-  lastId?: number,
+  lastId?: number | null,
 ): Promise<FundingDonationsResponse> => {
   const { data } = await axiosInstance.get(
     `/api/funding/${fundUuid}/donation`,
@@ -39,11 +37,8 @@ export const useFundingDonationsQuery = (fundUuid: string) => {
     PageParam
   >({
     queryKey: ["donations", fundUuid],
-    queryFn: ({ pageParam = { lastId: undefined } }) =>
-      fetchDonations(fundUuid, pageParam.lastId),
-    getNextPageParam: (lastPage) => {
-      return { lastId: lastPage.lastId };
-    },
-    initialPageParam: { lastId: undefined },
+    initialPageParam: undefined,
+    queryFn: ({ pageParam }) => fetchDonations(fundUuid, pageParam),
+    getNextPageParam: (lastPage) => lastPage.lastId,
   });
 };

--- a/src/types/Donation.ts
+++ b/src/types/Donation.ts
@@ -13,6 +13,17 @@ export interface Donation {
   delAt: Date;
 }
 
+export interface DonationListDto {
+  donId: number;
+  donUserId: number;
+  donUserNick: string;
+  donUserImg: string;
+  orderId: string;
+  donStat: DonationStatus;
+  donAmnt: number;
+  regAt: string;
+}
+
 export interface MyDonationListDto {
   donId: number;
   fundUuid: string;

--- a/src/utils/react-query/getQueryClient.ts
+++ b/src/utils/react-query/getQueryClient.ts
@@ -1,0 +1,37 @@
+import {
+  QueryClient,
+  defaultShouldDehydrateQuery,
+  isServer,
+} from "@tanstack/react-query";
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 60 * 1000,
+      },
+      dehydrate: {
+        // include pending queries in dehydration
+        shouldDehydrateQuery: (query) =>
+          defaultShouldDehydrateQuery(query) ||
+          query.state.status === "pending",
+      },
+    },
+  });
+}
+
+let browserQueryClient: QueryClient | undefined = undefined;
+
+export const getQueryClient = () => {
+  if (isServer) {
+    // Server: always make a new query client
+    return makeQueryClient();
+  } else {
+    // Browser: make a new query client if we don't already have one
+    // This is very important, so we don't re-make a new client if React
+    // suspends during the initial render. This may not be needed if we
+    // have a suspense boundary BELOW the creation of the query client
+    if (!browserQueryClient) browserQueryClient = makeQueryClient();
+    return browserQueryClient;
+  }
+};

--- a/src/utils/react-query/index.ts
+++ b/src/utils/react-query/index.ts
@@ -1,0 +1,1 @@
+export * from "./getQueryClient";

--- a/yarn.lock
+++ b/yarn.lock
@@ -1953,17 +1953,17 @@
   dependencies:
     tslib "^2.4.0"
 
-"@tanstack/query-core@5.29.0":
-  version "5.29.0"
-  resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.29.0.tgz#d0b3d12c07d5a47f42ab0c1ed4f317106f3d4b20"
-  integrity sha512-WgPTRs58hm9CMzEr5jpISe8HXa3qKQ8CxewdYZeVnA54JrPY9B1CZiwsCoLpLkf0dGRZq+LcX5OiJb0bEsOFww==
+"@tanstack/query-core@5.66.0":
+  version "5.66.0"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.66.0.tgz#163f670b3b4e3b3cdbff6698ad44b2edfcaed185"
+  integrity sha512-J+JeBtthiKxrpzUu7rfIPDzhscXF2p5zE/hVdrqkACBP8Yu0M96mwJ5m/8cPPYQE9aRNvXztXHlNwIh4FEeMZw==
 
-"@tanstack/react-query@^5.29.2":
-  version "5.29.2"
-  resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-5.29.2.tgz#c55ffbfaf9d8cf34212428db2b6c61ca6b545188"
-  integrity sha512-nyuWILR4u7H5moLGSiifLh8kIqQDLNOHGuSz0rcp+J75fNc8aQLyr5+I2JCHU3n+nJrTTW1ssgAD8HiKD7IFBQ==
+"@tanstack/react-query@^5.66.0":
+  version "5.66.0"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-5.66.0.tgz#9f7aa1b3e844ea6a0ad2ee61fccaed76e614b865"
+  integrity sha512-z3sYixFQJe8hndFnXgWu7C79ctL+pI0KAelYyW+khaNJ1m22lWrhJU2QrsTcRKMuVPtoZvfBYrTStIdKo+x0Xw==
   dependencies:
-    "@tanstack/query-core" "5.29.0"
+    "@tanstack/query-core" "5.66.0"
 
 "@tootallnate/quickjs-emscripten@^0.23.0":
   version "0.23.0"


### PR DESCRIPTION
## 📝 PR 설명
### `QueryClientProvider` 수정
- React Query를 서버 사이드 렌더링 페이지에서도 사용할 수 있게끔 `QueryClientProvider`를 수정했습니다.

### 펀딩 후원 내역 페이지
* 펀딩 후원 내역 페이지를 추가했습니다.
<img width="328" alt="image" src="https://github.com/user-attachments/assets/e6c10c12-e2d1-40e3-9ebe-9fce74534db0" />
<img width="328" alt="image" src="https://github.com/user-attachments/assets/3e854d0d-d88c-4863-9513-916c24cd7024" />


## 🏷️ Jira

## 👀 비고
_리뷰어가 참고해야 할 사항이 있으면 적어주세요._
