### PR TITLE
:bug: Fix: profile page 이슈 수정

### DIFF
--- a/src/app/(with-navbar)/fundings/page.suspense.tsx
+++ b/src/app/(with-navbar)/fundings/page.suspense.tsx
@@ -68,7 +68,7 @@ export default function FundingListContent() {
           .map((funding) => (
             <VerticalImgCard
               key={funding.fundUuid}
-              image={funding.fundImg ?? "/dummy/present.webp"}
+              image={funding.fundImgUrls[0] ?? "/dummy/present.webp"}
               userId={funding.fundUserNick || "익명"}
               title={funding.fundTitle}
               theme={funding.fundTheme}

--- a/src/app/(with-navbar)/page.suspense.tsx
+++ b/src/app/(with-navbar)/page.suspense.tsx
@@ -72,7 +72,7 @@ export default function MainPageContent() {
                 <SwiperSlide key={`slide-${funding.fundUuid}`}>
                   <HorizontalImgCard
                     key={funding.fundUuid}
-                    image={funding.fundImg ?? "/dummy/present.webp"}
+                    image={funding.fundImgUrls[0] ?? "/dummy/present.webp"}
                     userId={funding.fundUserNick || "익명"}
                     title={funding.fundTitle}
                     theme={funding.fundTheme}
@@ -108,7 +108,7 @@ export default function MainPageContent() {
           .map((funding) => (
             <VerticalImgCard
               key={funding.fundUuid}
-              image={funding.fundImg ?? "/dummy/present.webp"}
+              image={funding.fundImgUrls[0] ?? "/dummy/present.webp"}
               userId={funding.fundUserNick || "익명"}
               title={funding.fundTitle}
               theme={funding.fundTheme}

--- a/src/app/(with-navbar)/profile/[userId]/page.suspense.tsx
+++ b/src/app/(with-navbar)/profile/[userId]/page.suspense.tsx
@@ -17,7 +17,7 @@ export default function MyPageContent({ myId, friendId }: Props) {
 
   const { data: profileUser } = useUserQuery(friendId);
 
-  // 프로필 유저 - 진행중인 펀딩
+  // 프로필 유저 - 진행 중인 펀딩
   const { data: profileOngoingQuery } = useFundingsQuery(
     {
       fundPublFilter: "mine",

--- a/src/app/(with-navbar)/profile/[userId]/page.suspense.tsx
+++ b/src/app/(with-navbar)/profile/[userId]/page.suspense.tsx
@@ -5,7 +5,6 @@ import { FundingStatusValue } from "@/types/Funding.enum";
 import useFundingsQuery from "@/query/useFundingsQuery";
 import UserProfile from "./view/UserProfile";
 import { FundingList } from "./view/FundingList";
-import useCurrentUserQuery from "@/query/useCurrentUserQuery";
 import useUserQuery from "@/query/useUserQuery";
 
 interface Props {
@@ -16,32 +15,25 @@ interface Props {
 export default function MyPageContent({ myId, friendId }: Props) {
   const [tab, setTab] = useState<FundingStatusValue>("진행 중");
 
-  const { data: loginUser } = useCurrentUserQuery();
-  const { data: anotherUser } = useUserQuery(friendId);
+  const { data: profileUser } = useUserQuery(friendId);
 
-  // 나의 펀딩 - 진행중
-  const { data: ongoinMyFundingQueryResponse } = useFundingsQuery({
-    fundPublFilter: "mine",
-    status: "ongoing",
-  });
+  // 프로필 유저 - 진행중인 펀딩
+  const { data: profileOngoingQuery } = useFundingsQuery(
+    {
+      fundPublFilter: "mine",
+      status: "ongoing",
+    },
+    profileUser?.userId,
+  );
 
-  // 나의 펀딩 - 종료됨
-  const { data: endedMyFundingQueryResponse } = useFundingsQuery({
-    fundPublFilter: "mine",
-    status: "ended",
-  });
-
-  // 다른 사람들의 펀딩 - 진행중
-  const { data: ongoingOthersFundingQueryResponse } = useFundingsQuery({
-    fundPublFilter: "both",
-    status: "ongoing",
-  });
-
-  // 다른 사람들의 펀딩 - 종료됨
-  const { data: endedOthersFundingQueryResponse } = useFundingsQuery({
-    fundPublFilter: "both",
-    status: "ended",
-  });
+  // 프로필 유저 - 종료된 펀딩
+  const { data: profileEndedQuery } = useFundingsQuery(
+    {
+      fundPublFilter: "mine",
+      status: "ended",
+    },
+    profileUser?.userId,
+  );
 
   const handleTabChange = (
     event: SyntheticEvent,
@@ -49,17 +41,6 @@ export default function MyPageContent({ myId, friendId }: Props) {
   ) => {
     setTab(newTab);
   };
-
-  // 프로필 유저 정보
-  const profileUser = friendId === myId ? loginUser : anotherUser;
-  const profileOngoingQuery =
-    friendId === myId
-      ? ongoinMyFundingQueryResponse
-      : ongoingOthersFundingQueryResponse;
-  const profileEndedQuery =
-    friendId === myId
-      ? endedMyFundingQueryResponse
-      : endedOthersFundingQueryResponse;
 
   if (!profileUser) {
     // TODO: 유저정보가 없을 때

--- a/src/app/(with-navbar)/profile/[userId]/view/FundingList.tsx
+++ b/src/app/(with-navbar)/profile/[userId]/view/FundingList.tsx
@@ -24,7 +24,7 @@ export const FundingList = ({ fundings }: Props) => {
       {fundings.map((funding) => (
         <HorizontalImgCard
           key={funding.fundUuid}
-          image={funding.fundImg ?? "/dummy/present.webp"}
+          image={funding.fundImgUrls[0] ?? "/dummy/present.webp"}
           userId={funding.fundUserNick || "익명"}
           title={funding.fundTitle}
           theme={funding.fundTheme}

--- a/src/app/(without-navbar)/notification/page.tsx
+++ b/src/app/(without-navbar)/notification/page.tsx
@@ -1,8 +1,7 @@
 "use client";
 import { Box, Button, Grid, Typography } from "@mui/material";
 import NotificationsOffIcon from "@mui/icons-material/NotificationsOff";
-import React, { useRef, useState } from "react";
-import { useRouter } from "next/navigation";
+import React, { useEffect, useRef, useState } from "react";
 import FilterButtonGroup from "@/components/theme/components/FilterButtonGroup";
 import useNotificationsQuery from "@/query/useNotificationsQuery";
 import {
@@ -18,8 +17,8 @@ import LayoutWithPrev from "@/components/layout/layout-with-prev";
 import theme from "@/components/theme";
 
 export default function AlarmHistoryPage() {
-  const router = useRouter();
   const [filter, setFilter] = useState<NotiFilter>("all");
+  const [hasVisited, setHasVisited] = useState<boolean>(false); // 페이지 방문 플래그
 
   const entryTimeRef = useRef(new Date()); // 페이지 진입 시점 기록
   const { mutate: readNoti } = useReadNotification(entryTimeRef.current); // isRead: false -> true
@@ -47,6 +46,17 @@ export default function AlarmHistoryPage() {
     rootMargin: "0px",
     threshold: 1.0,
   });
+
+  useEffect(() => {
+    return () => {
+      if (hasVisited) readNoti();
+    };
+  }, [readNoti, hasVisited]);
+
+  // 읽지 않은 알림 확인 후 페이지 나가면 방문한 페이지로 설정
+  useEffect(() => {
+    setHasVisited(true);
+  }, []);
 
   if (!notificationResponse) {
     return <></>;

--- a/src/app/(without-navbar)/notification/page.tsx
+++ b/src/app/(without-navbar)/notification/page.tsx
@@ -15,8 +15,11 @@ import EmptyState from "@/components/empty-state/EmptyState";
 import useReadNotification from "@/query/useReadNotification";
 import LayoutWithPrev from "@/components/layout/layout-with-prev";
 import theme from "@/components/theme";
+import Error from "@/app/error";
+import { useRouter } from "next/navigation";
 
 export default function AlarmHistoryPage() {
+  const router = useRouter();
   const [filter, setFilter] = useState<NotiFilter>("all");
   const [hasVisited, setHasVisited] = useState<boolean>(false); // 페이지 방문 플래그
 
@@ -100,7 +103,12 @@ export default function AlarmHistoryPage() {
         {isLoading ? (
           <Typography>Loading...</Typography>
         ) : error ? (
-          <Typography>로딩 중 에러</Typography>
+          <Error
+            error={error}
+            reset={() => {
+              router.push("/notification");
+            }}
+          />
         ) : notificationResponse.pages.length !== 0 ? (
           <Grid spacing={2}>
             {/*읽지 않은 알림이 있을 때*/}

--- a/src/app/(without-navbar)/notification/page.tsx
+++ b/src/app/(without-navbar)/notification/page.tsx
@@ -1,14 +1,5 @@
 "use client";
-import {
-  AppBar,
-  Box,
-  Button,
-  IconButton,
-  Stack,
-  Toolbar,
-  Typography,
-} from "@mui/material";
-import ArrowBackIosNewIcon from "@mui/icons-material/ArrowBackIosNew";
+import { Box, Button, Grid, Typography } from "@mui/material";
 import NotificationsOffIcon from "@mui/icons-material/NotificationsOff";
 import React, { useRef, useState } from "react";
 import { useRouter } from "next/navigation";
@@ -24,6 +15,7 @@ import NotificationWrapper from "@/app/(without-navbar)/notification/view/Notifi
 import EmptyState from "@/components/empty-state/EmptyState";
 import useReadNotification from "@/query/useReadNotification";
 import LayoutWithPrev from "@/components/layout/layout-with-prev";
+import theme from "@/components/theme";
 
 export default function AlarmHistoryPage() {
   const router = useRouter();
@@ -41,12 +33,6 @@ export default function AlarmHistoryPage() {
   } = useNotificationsQuery({
     notiFilter: filter,
   });
-
-  // 뒤로가기 버튼 클릭
-  const handleClick = () => {
-    readNoti();
-    router.back();
-  };
 
   // 무한 스크롤
   const loadMore = () => {
@@ -71,132 +57,141 @@ export default function AlarmHistoryPage() {
   };
 
   const filterButtonStyle = (isActive: boolean) => ({
-    fontWeight: isActive ? "bold" : "normal",
-    backgroundColor: isActive ? "#ECF0EF" : "#fff",
-    borderColor: isActive ? "#4F4635" : "#d0d0d0",
-    color: isActive ? "#4F4635" : "#4F4635",
-    borderWidth: isActive ? "1.5px" : "1px",
+    backgroundColor: isActive ? theme.palette.primary.main : "#fff",
+    borderColor: isActive ? theme.palette.primary.main : "#d0d0d0",
+    color: isActive ? "#fff" : "#000",
   });
 
   return (
     <LayoutWithPrev title="알림">
-      <FilterButtonGroup fullWidth>
-        {Object.keys(NotiFilterMap).map((key) => (
-          <Button
-            key={key}
-            onClick={() => handleFilterChange(key as NotiFilter)}
-            style={filterButtonStyle(key === filter)}
-          >
-            {getNotiFilterValue(key as NotiFilter)}
-          </Button>
-        ))}
-      </FilterButtonGroup>
+      <Box
+        sx={{
+          position: "sticky",
+          top: 52,
+          zIndex: 1,
+          bgcolor: "white",
+          paddingX: 1,
+        }}
+      >
+        <FilterButtonGroup fullWidth>
+          {Object.keys(NotiFilterMap).map((key) => (
+            <Button
+              key={key}
+              onClick={() => handleFilterChange(key as NotiFilter)}
+              style={filterButtonStyle(key === filter)}
+            >
+              {getNotiFilterValue(key as NotiFilter)}
+            </Button>
+          ))}
+        </FilterButtonGroup>
+      </Box>
 
-      <Box>
-        <Stack spacing={2} sx={{ py: 2 }}>
-          {isLoading ? (
-            <Typography>Loading...</Typography>
-          ) : error ? (
-            <Typography>로딩 중 에러</Typography>
-          ) : notificationResponse.pages.length !== 0 ? (
-            <>
-              <Stack>
-                {/*읽지 않은 알림이 있을 때*/}
+      <Box sx={{ flexGrow: 1 }}>
+        {isLoading ? (
+          <Typography>Loading...</Typography>
+        ) : error ? (
+          <Typography>로딩 중 에러</Typography>
+        ) : notificationResponse.pages.length !== 0 ? (
+          <Grid spacing={2}>
+            {/*읽지 않은 알림이 있을 때*/}
+            {notificationResponse?.pages
+              ?.flatMap((page) => page.noti)
+              .filter((notification) => !notification.isRead).length > 0 ? (
+              <Grid>
+                {/* 읽지 않은 알림 */}
+                <Grid sx={notiContainerStyles(false)}>
+                  {notificationResponse?.pages
+                    ?.flatMap((page) => page.noti)
+                    .filter((notification) => !notification.isRead)
+                    .map((notification) => (
+                      <NotificationWrapper
+                        key={`notification-${notification.notiId}`}
+                        notification={notification}
+                        entryTimeRef={entryTimeRef}
+                      />
+                    ))}
+                </Grid>
+
+                {/* 이전 알림 문구 표시*/}
+                <Grid
+                  sx={{
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    pt: 2,
+                    px: 1.5,
+                  }}
+                >
+                  <Grid
+                    sx={{
+                      flex: 1,
+                      borderBottom: "0.5px solid #bdbdbd",
+                      height: 0,
+                      marginRight: "8px",
+                    }}
+                  />
+                  <Typography variant="subtitle1" sx={{ color: "#bdbdbd" }}>
+                    이전 알림
+                  </Typography>
+                  <Grid
+                    sx={{
+                      flex: 1,
+                      borderBottom: "0.5px solid #bdbdbd",
+                      height: 0,
+                      marginLeft: "8px",
+                    }}
+                  />
+                </Grid>
+
+                {/* 이전 알림들  */}
+                <Grid sx={notiContainerStyles(true)}>
+                  {notificationResponse?.pages
+                    ?.flatMap((page) => page.noti)
+                    .filter((notification) => notification.isRead)
+                    .map((notification) => (
+                      <NotificationWrapper
+                        key={`notification-${notification.notiId}`}
+                        notification={notification}
+                        entryTimeRef={entryTimeRef}
+                      />
+                    ))}
+                </Grid>
+              </Grid>
+            ) : (
+              <Grid sx={notiContainerStyles(true)}>
+                {/* 읽지 않은 알림이 없을 때: 이전 알림 문구 표시 없이 바로 읽은 알림 보여줌 */}
                 {notificationResponse?.pages
                   ?.flatMap((page) => page.noti)
-                  .filter((notification) => !notification.isRead).length > 0 ? (
-                  <>
-                    {/* 읽지 않은 알림 */}
-                    {notificationResponse?.pages
-                      ?.flatMap((page) => page.noti)
-                      .filter((notification) => !notification.isRead)
-                      .map((notification) => (
-                        <NotificationWrapper
-                          key={`notification-${notification.notiId}`}
-                          notification={notification}
-                          entryTimeRef={entryTimeRef}
-                        />
-                      ))}
-
-                    {/* 이전 알림 문구 표시*/}
-                    <Stack>
-                      <Box
-                        sx={{
-                          display: "flex",
-                          alignItems: "center",
-                          justifyContent: "center",
-                          pt: 2,
-                          px: 1.5,
-                        }}
-                      >
-                        <Box
-                          sx={{
-                            flex: 1,
-                            borderBottom: "0.5px solid #bdbdbd",
-                            height: 0,
-                            marginRight: "8px",
-                          }}
-                        />
-                        <Typography
-                          variant="subtitle1"
-                          sx={{ color: "#bdbdbd" }}
-                        >
-                          이전 알림
-                        </Typography>
-                        <Box
-                          sx={{
-                            flex: 1,
-                            borderBottom: "0.5px solid #bdbdbd",
-                            height: 0,
-                            marginLeft: "8px",
-                          }}
-                        />
-                      </Box>
-                      {notificationResponse?.pages
-                        ?.flatMap((page) => page.noti)
-                        .filter((notification) => notification.isRead)
-                        .map((notification) => (
-                          <NotificationWrapper
-                            key={`notification-${notification.notiId}`}
-                            notification={notification}
-                            entryTimeRef={entryTimeRef}
-                          />
-                        ))}
-                    </Stack>
-                  </>
-                ) : (
-                  <>
-                    {/* 읽지 않은 알림이 없을 때: 이전 알림 문구 표시 없이 바로 읽은 알림 보여줌 */}
-                    {notificationResponse?.pages
-                      ?.flatMap((page) => page.noti)
-                      .filter((notification) => notification.isRead)
-                      .map((notification) => (
-                        <NotificationWrapper
-                          key={`notification-${notification.notiId}`}
-                          notification={notification}
-                          entryTimeRef={entryTimeRef}
-                        />
-                      ))}
-                  </>
-                )}
-              </Stack>
-            </>
-          ) : (
-            <EmptyState
-              icon={
-                <NotificationsOffIcon sx={{ fontSize: 60, color: "#FFC107" }} />
-              }
-              title={"앗, 아직 도착한 알림이 없어요"}
-              message={"새로운 소식이 도착하면 알려드릴게요!"}
-            />
-          )}
-          <div
-            className={"as"}
-            ref={observerRef}
-            style={{ height: "20px", background: "transparent" }}
+                  .filter((notification) => notification.isRead)
+                  .map((notification) => (
+                    <NotificationWrapper
+                      key={`notification-${notification.notiId}`}
+                      notification={notification}
+                      entryTimeRef={entryTimeRef}
+                    />
+                  ))}
+              </Grid>
+            )}
+          </Grid>
+        ) : (
+          <EmptyState
+            icon={
+              <NotificationsOffIcon sx={{ fontSize: 60, color: "#FFC107" }} />
+            }
+            title={"앗, 아직 도착한 알림이 없어요"}
+            message={"새로운 소식이 도착하면 알려드릴게요!"}
           />
-        </Stack>
+        )}
+        <div
+          className={"as"}
+          ref={observerRef}
+          style={{ height: "20px", background: "transparent" }}
+        />
       </Box>
     </LayoutWithPrev>
   );
 }
+
+const notiContainerStyles = (isRead: boolean) => ({
+  backgroundColor: isRead ? "transparent" : "#fff6f6",
+});

--- a/src/app/(without-navbar)/notification/view/NotificationWrapper.tsx
+++ b/src/app/(without-navbar)/notification/view/NotificationWrapper.tsx
@@ -19,16 +19,8 @@ export default function NotificationWrapper({
   entryTimeRef,
 }: Props) {
   const router = useRouter();
-  const {
-    sendId,
-    sendImg,
-    sendNick,
-    notiType,
-    subId,
-    notiTime,
-    fundTitle,
-    isRead,
-  } = notification;
+  const { sendId, sendImg, sendNick, notiType, subId, notiTime, fundTitle } =
+    notification;
   const { mutate: readNoti } = useReadNotification(entryTimeRef.current); // isRead: false -> true
 
   const handleClickUserProfile = () => {
@@ -56,13 +48,7 @@ export default function NotificationWrapper({
       justifyContent="flex-start"
       alignItems="flex-start"
       spacing={2}
-      sx={{
-        px: 1.5,
-        py: 2.5,
-        width: "100%",
-        position: "relative",
-        backgroundColor: isRead ? "transparent" : "#fff6f6",
-      }}
+      sx={{ px: 3, py: 3, width: "100%", position: "relative" }}
     >
       {notiType !== NotiType.FundClose &&
         notiType !== NotiType.FundAchieve &&

--- a/src/app/(without-navbar)/profile/[userId]/friends/page.tsx
+++ b/src/app/(without-navbar)/profile/[userId]/friends/page.tsx
@@ -9,23 +9,14 @@ import {
   ListItemText,
 } from "@mui/material";
 import { FriendQueryDto } from "@/types/Friend";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useRouter } from "next/navigation";
 import PersonSearchIcon from "@mui/icons-material/PersonSearch";
 import EmptyState from "@/components/empty-state/EmptyState";
 import LayoutWithPrev from "@/components/layout/layout-with-prev";
 import DeleteFriendButton from "@/app/(without-navbar)/profile/[userId]/friends/view/DeleteFriendButton";
 
-interface Params {
-  params: {
-    userId: string;
-  };
-}
-
-export default function FriendsListPage({ params }: Params) {
+export default function FriendsListPage() {
   const router = useRouter();
-  const searchParams = useSearchParams();
-  const userId = Number(params.userId);
-  const userNick = searchParams.get("userNick");
   const { data: friendsList } = useFriendsQuery();
 
   if (!friendsList) {

--- a/src/components/avatar/AvatarWithBadge.tsx
+++ b/src/components/avatar/AvatarWithBadge.tsx
@@ -3,7 +3,7 @@ import { Avatar, Badge } from "@mui/material";
 
 interface Props {
   imgSrc?: string;
-  badge: ReactNode;
+  badge?: ReactNode;
   onClick?: () => void;
   avatarSx?: CSSProperties;
 }

--- a/src/components/avatar/ProfileImage.tsx
+++ b/src/components/avatar/ProfileImage.tsx
@@ -4,6 +4,7 @@ import { grey } from "@mui/material/colors";
 import { AvatarWithBadge } from "@/components/avatar";
 import { BottomSheet, useOverlay } from "@/components/overlay";
 import ProfileBottomSheet from "@/app/(with-navbar)/profile/[userId]/view/ProfileBottomSheet";
+import { useCookie } from "@/hook/useCookie";
 
 interface Props {
   imgSrc?: string;
@@ -12,6 +13,8 @@ interface Props {
 }
 
 export const ProfileImage = ({ imgSrc, onSubmit, userId }: Props) => {
+  const loginUserId = useCookie<number>("userId");
+
   // 오버레이 훅
   const overlay = useOverlay();
 
@@ -46,7 +49,7 @@ export const ProfileImage = ({ imgSrc, onSubmit, userId }: Props) => {
     handleClose();
   };
 
-  return (
+  return userId === loginUserId ? (
     <AvatarWithBadge
       imgSrc={imgSrc}
       badge={
@@ -56,6 +59,8 @@ export const ProfileImage = ({ imgSrc, onSubmit, userId }: Props) => {
       }
       onClick={openBottomSheet}
     />
+  ) : (
+    <AvatarWithBadge imgSrc={imgSrc} />
   );
 };
 

--- a/src/components/card/VerticalImgCard.tsx
+++ b/src/components/card/VerticalImgCard.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import React from "react";
 import {
   Card as MaterialCard,

--- a/src/components/layout/layout-with-prev/layout.css.ts
+++ b/src/components/layout/layout-with-prev/layout.css.ts
@@ -35,7 +35,7 @@ export const icon = style({
 export const titleSpan = style({
   fontSize: "18px",
   lineHeight: "22px",
-  fontWeight: 500,
+  fontWeight: 600,
   color: "#424242",
   position: "absolute",
   left: "50%",

--- a/src/components/theme/components/FilterButtonGroup.ts
+++ b/src/components/theme/components/FilterButtonGroup.ts
@@ -5,7 +5,7 @@ const FilterButtonGroup = styled(ButtonGroup)({
     borderColor: "#d0d0d0",
     flex: 1,
     borderRadius: 10,
-    color: "#4F4635",
+    color: "#000",
     backgroundColor: "#fff",
     margin: "5px",
     padding: "5px",

--- a/src/query/useFriendCount.ts
+++ b/src/query/useFriendCount.ts
@@ -9,7 +9,7 @@ interface QueryResponse {
 const fetchFriendCount = async (
   userId: number,
 ): Promise<CommonResponse<QueryResponse>> => {
-  const { data } = await axios.get(`/api/friends/${userId}`);
+  const { data } = await axios.get(`/api/friend/${userId}`);
   return data;
 };
 

--- a/src/types/Funding.ts
+++ b/src/types/Funding.ts
@@ -20,6 +20,7 @@ export interface Funding {
   endAt: string;
   regAt: string;
   fundUserNick?: string;
+  fundImgUrls: string[];
 }
 
 // 펀딩 상세 불러올 때 사용


### PR DESCRIPTION
## 📝 PR 설명
### 프로필 페이지 이슈 해결
- 친구 수 api path 수정
- 펀딩글 썸네일 fundImgUrls 배열의 0번째 인덱스 참조
<img width="355" alt="스크린샷 2025-02-20 오후 5 52 46" src="https://github.com/user-attachments/assets/d8b04776-c23d-4d66-8dbd-ea42c3377575" />
<img width="356" alt="스크린샷 2025-02-20 오후 5 52 57" src="https://github.com/user-attachments/assets/fd047aa5-64f4-49a0-9032-11e2d29fcfeb" />


- 상대방 프로필 이미지 변경 불가능하도록 수정
<img width="356" alt="프사" src="https://github.com/user-attachments/assets/62aa6785-8b42-4f8f-9d30-7dc5f2a9863d" />
<img width="356" alt="프사후" src="https://github.com/user-attachments/assets/7a569910-78ab-4c7b-a124-95176f4020b0" />


- 프로필 유저의 작성글만 보이도록 수정
<img width="354" alt="목록" src="https://github.com/user-attachments/assets/6672313d-ade4-46ac-8f1e-2929b63fe931" />
<img width="354" alt="스크린샷 2025-02-20 오후 6 23 56" src="https://github.com/user-attachments/assets/8631995a-d73e-4c93-9b64-8258b5d5604d" />

## 🏷️ Jira
[WISH-450](https://wishfund.atlassian.net/browse/WISH-450)

## 👀 비고
- 응답으로 내려오는 fundImgUrls 배열 안에 유효하지 않은 값들이 있어 엑박이 뜨고 있습니다.


[WISH-450]: https://wishfund.atlassian.net/browse/WISH-450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ